### PR TITLE
Added uuid loggable (requestId) to root context

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -9,13 +10,11 @@ import (
 	"strings"
 	"sync"
 
-	context "context"
+	"github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs/repo/config"
-	cors "github.com/rs/cors"
-
-	cmds "github.com/ipfs/go-ipfs-cmds"
-
 	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-loggables"
+	"github.com/rs/cors"
 )
 
 var log = logging.Logger("cmds/http")
@@ -139,6 +138,7 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithCancel(node.Context())
 	defer cancel()
+	ctx = logging.ContextWithLoggable(ctx, loggables.Uuid("requestId"))
 	if cn, ok := w.(http.CloseNotifier); ok {
 		clientGone := cn.CloseNotify()
 		go func() {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
       "hash": "QmUyfy4QSr3NXym4etEiRyxBLqqAeKHJuRdi8AACxg63fZ",
       "name": "go-ipfs-cmdkit",
       "version": "0.3.5"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmT4PgCNdv73hnFAqzHqwW44q7M9PWpykSswHDxndquZbc",
+      "name": "go-libp2p-loggables",
+      "version": "1.1.8"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
Every log event resulting from a command will have a uuid associated with it.
Copied from https://github.com/ipfs/go-ipfs/pull/4392.

Via https://github.com/ipfs/go-ipfs/pull/4415