### PR TITLE
Fix JSON Parsing

### DIFF
--- a/http/response.go
+++ b/http/response.go
@@ -67,18 +67,15 @@ func (res *Response) RawNext() (interface{}, error) {
 		}
 	}
 
-	a := &cmds.Any{}
-	a.Add(&cmdkit.Error{})
-	a.Add(res.req.Command().Type)
-
-	err := res.dec.Decode(a)
+	m := &cmds.MaybeError{Value: res.req.Command().Type}
+	err := res.dec.Decode(m)
 
 	// last error was sent as value, now we get the same error from the headers. ignore and EOF!
 	if err != nil && res.err != nil && err.Error() == res.err.Error() {
 		err = io.EOF
 	}
 
-	return a.Interface(), err
+	return m.Get(), err
 }
 
 func (res *Response) Next() (interface{}, error) {

--- a/maybeerror_test.go
+++ b/maybeerror_test.go
@@ -32,11 +32,38 @@ type anyTestCase struct {
 func TestMaybeError(t *testing.T) {
 	testcases := []anyTestCase{
 		anyTestCase{
+			Value: &Foo{},
+			JSON:  `{"Bar":23}{"Bar":42}{"Message":"some error", "Type": "error"}`,
+			Decoded: []ValueError{
+				ValueError{Error: nil, Value: &Foo{23}},
+				ValueError{Error: nil, Value: &Foo{42}},
+				ValueError{Error: nil, Value: cmdkit.Error{Message: "some error", Code: 0}},
+			},
+		},
+		anyTestCase{
 			Value: Foo{},
 			JSON:  `{"Bar":23}{"Bar":42}{"Message":"some error", "Type": "error"}`,
 			Decoded: []ValueError{
 				ValueError{Error: nil, Value: &Foo{23}},
 				ValueError{Error: nil, Value: &Foo{42}},
+				ValueError{Error: nil, Value: cmdkit.Error{Message: "some error", Code: 0}},
+			},
+		},
+		anyTestCase{
+			Value: &Bar{},
+			JSON:  `{"Foo":""}{"Foo":"Qmabc"}{"Message":"some error", "Type": "error"}`,
+			Decoded: []ValueError{
+				ValueError{Error: nil, Value: &Bar{""}},
+				ValueError{Error: nil, Value: &Bar{"Qmabc"}},
+				ValueError{Error: nil, Value: cmdkit.Error{Message: "some error", Code: 0}},
+			},
+		},
+		anyTestCase{
+			Value: Bar{},
+			JSON:  `{"Foo":""}{"Foo":"Qmabc"}{"Message":"some error", "Type": "error"}`,
+			Decoded: []ValueError{
+				ValueError{Error: nil, Value: &Bar{""}},
+				ValueError{Error: nil, Value: &Bar{"Qmabc"}},
 				ValueError{Error: nil, Value: cmdkit.Error{Message: "some error", Code: 0}},
 			},
 		},


### PR DESCRIPTION
@Stebalien reported a panic [here](https://github.com/ipfs/go-ipfs/issues/4436) that is caused by the cmds layer to not correctly parse a value that results in a zero value.

The problem is that I tried to make a type that takes a set of `interface{}` values, tries to decode the JSON into each of them and returns the first one that doesn't throw an error or result in a zero value. If this doesn't work for any of the supplied types, instead unmarshal into a `map[string]interface{}`.
This approach obviously fails if we want to parse a value that actually results in a zero value. This is what happens in the issue mentioned above.

So instead I made a type that expects either a cmdkit.Error or a value, and unmarshals into the value if unmarshaling into an error fails.

I used this version of go-ipfs-cmds to build go-ipfs and the panic does not occur anymore.

If the PR is accepted I'll squash and gx publish.

Regarding the tests, CI will only work after at cmds0.5 is done, which I'm working on when I'm not busy fixing panics ;)