### PR TITLE
gx: update go-multihash

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.4.13: QmP7p39qT9NivtvNBMj8uVqz3iNZSwfhN32ZZEehpKThNG
+0.4.14: QmdobqHSFbQGbfSqMWfUZgZyLkasEa2tspgrAkwVNjTA2a

--- a/package.json
+++ b/package.json
@@ -20,20 +20,20 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU",
+      "hash": "QmPsAfmDBnZN3kZGSuNwvCNDZiHneERSKmRcFyG3UkvcT3",
       "name": "go-ipfs-util",
-      "version": "1.2.5"
+      "version": "1.2.6"
     },
     {
-      "hash": "QmUyfy4QSr3NXym4etEiRyxBLqqAeKHJuRdi8AACxg63fZ",
+      "hash": "QmQp2a2Hhb7F6eK2A5hN8f9aJy4mtkEikL9Zj4cgB7d1dD",
       "name": "go-ipfs-cmdkit",
-      "version": "0.3.5"
+      "version": "0.3.6"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmT4PgCNdv73hnFAqzHqwW44q7M9PWpykSswHDxndquZbc",
+      "hash": "QmSvcDkiRwB8LuMhUtnvhum2C851Mproo75ZDD19jx43tD",
       "name": "go-libp2p-loggables",
-      "version": "1.1.8"
+      "version": "1.1.9"
     }
   ],
   "gxVersion": "0.10.0",
@@ -41,6 +41,6 @@
   "license": "MIT",
   "name": "go-ipfs-cmds",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.4.13"
+  "version": "0.4.14"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-peer/pull/20
- https://github.com/libp2p/go-libp2p-secio/pull/23
- https://github.com/multiformats/go-multiaddr/pull/61
- https://github.com/multiformats/go-multiaddr-net/pull/33
- https://github.com/whyrusleeping/iptb/pull/37
- https://github.com/whyrusleeping/mafmt/pull/7
- https://github.com/libp2p/go-libp2p-peerstore/pull/18
- https://github.com/ipfs/go-ipfs-util/pull/6
- https://github.com/libp2p/go-libp2p-transport/pull/25
- https://github.com/libp2p/go-peerstream/pull/19
- https://github.com/libp2p/go-libp2p-loggables/pull/14
- https://github.com/libp2p/go-tcp-transport/pull/17
- https://github.com/libp2p/go-maddr-filter/pull/4
- https://github.com/libp2p/go-ws-transport/pull/28
- https://github.com/libp2p/go-addr-util/pull/9
- https://github.com/ipfs/go-cid/pull/39
- https://github.com/libp2p/go-testutil/pull/15
- https://github.com/libp2p/go-libp2p-interface-conn/pull/4
- https://github.com/libp2p/go-libp2p-interface-pnet/pull/6
- https://github.com/libp2p/go-libp2p-conn/pull/21
- https://github.com/libp2p/go-libp2p-net/pull/15
- https://github.com/libp2p/go-libp2p-metrics/pull/7
- https://github.com/libp2p/go-libp2p-interface-connmgr/pull/2
- https://github.com/libp2p/go-libp2p-host/pull/10
- https://github.com/libp2p/go-libp2p-swarm/pull/46
- https://github.com/libp2p/go-libp2p-nat/pull/4
- https://github.com/libp2p/go-libp2p-netutil/pull/16
- https://github.com/libp2p/go-libp2p-blankhost/pull/7
- https://github.com/libp2p/go-libp2p-circuit/pull/24
- https://github.com/multiformats/go-multiaddr-dns/pull/6
- https://github.com/libp2p/go-libp2p/pull/251
- https://github.com/libp2p/go-libp2p-record/pull/7
- https://github.com/libp2p/go-libp2p-kbucket/pull/16
- https://github.com/libp2p/go-libp2p-routing/pull/19
- https://github.com/libp2p/go-libp2p-kad-dht/pull/105
- https://github.com/jbenet/hang-fds/pull/2
- https://github.com/libp2p/go-floodsub/pull/51
- https://github.com/ipfs/go-block-format/pull/9
- https://github.com/ipfs/go-ipld-format/pull/30
- https://github.com/ipfs/go-ipld-cbor/pull/31
- https://github.com/libp2p/go-libp2p-dummy-conn/pull/5
- https://github.com/libp2p/go-libp2p-pnet/pull/17
- https://github.com/ipfs/go-ipfs-cmdkit/pull/7


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace