### PR TITLE
MaybeError: add support for untyped parsing

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -188,11 +188,18 @@ func (m *MaybeError) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// make sure we are working with a pointer here
-	v := reflect.ValueOf(m.Value)
-	if v.Kind() != reflect.Ptr {
-		m.Value = reflect.New(v.Type()).Interface()
+	if m.Value != nil {
+		// make sure we are working with a pointer here
+		v := reflect.ValueOf(m.Value)
+		if v.Kind() != reflect.Ptr {
+			m.Value = reflect.New(v.Type()).Interface()
+		}
+
+		err = json.Unmarshal(data, m.Value)
+	} else {
+		// let the json decoder decode into whatever it finds appropriate
+		err = json.Unmarshal(data, &m.Value)
 	}
 
-	return json.Unmarshal(data, m.Value)
+	return err
 }


### PR DESCRIPTION
https://github.com/ipfs/go-ipfs/pull/4455 fails because the `dag get` command does not have a type set (i.e. `cmd.Type` is `nil`). This PR adds support for this situation in `MaybeError`, using `encoding/json`'s default types (i.e. `float64` for numbers, `map[string]interface{}` for objects etc.).
