### PR TITLE
Fix race conditions

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -195,6 +195,14 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
+	d := re.(Doner)
+	select {
+	case <-d.Done():
+	case <-req.Context().Done():
+		log.Error("waiting for http.Responseemitter to close but then %s", req.Context().Err())
+		// too late to send an error, just return
+	}
+
 	return
 }
 

--- a/http/responseemitter.go
+++ b/http/responseemitter.go
@@ -60,6 +60,8 @@ type responseEmitter struct {
 	streaming bool
 	once      sync.Once
 	method    string
+
+	closeOnce sync.Once
 	closeWait chan struct{}
 }
 
@@ -145,13 +147,7 @@ func (re *responseEmitter) SetLength(l uint64) {
 
 func (re *responseEmitter) Close() error {
 	re.once.Do(func() { re.preamble(nil) })
-
-	select {
-	case <-re.closeWait:
-		return nil // already closed
-	default:
-		close(re.closeWait)
-	}
+	re.closeOnce.Do(func() { close(re.closeWait) })
 
 	return nil
 }


### PR DESCRIPTION
Between 0.4.11 and 0.4.13 two race conditions were introduced. This PR fixes them.

One race condition was related to the http handler returning before the `res.Send()` goroutine in legacy.go was done. It kept writing to the http stream beyond the http connection's lifetime.

The other race condition was `re.streaming` was accessed concurrently. I moved the assignment to the preamble an made sure that all the code that called the preamble wait for it to complete before doing anything.

I also added the Doner interface and made http.responseEmitter implement it. It contains a function `Done` that returns a read-only channel that is closed once the ResponseEmitter is closed. That way users of the ResponseEmitter can wait for it to complete before continuing.