### PR TITLE
First check for HEAD request, then error out if writer is nil

### DIFF
--- a/http/responseemitter.go
+++ b/http/responseemitter.go
@@ -94,6 +94,11 @@ func (re *responseEmitter) Emit(value interface{}) error {
 
 	re.once.Do(func() { re.preamble(value) })
 
+	// return immediately if this is a head request
+	if re.method == "HEAD" {
+		return nil
+	}
+
 	if single, ok := value.(cmds.Single); ok {
 		value = single.Value
 		defer re.Close()
@@ -105,11 +110,6 @@ func (re *responseEmitter) Emit(value interface{}) error {
 
 	// ignore those
 	if value == nil {
-		return nil
-	}
-
-	// return immediately if this is a head request
-	if re.method == "HEAD" {
 		return nil
 	}
 


### PR DESCRIPTION
When an error is the first value that is emitted on a HEAD request, the writer is closed and set to nil in the preamble. Back in Emit, we then check wheter the writer is nil and, if that is the case, return an error. Only later we check whether we have a HEAD request and we expect the writer to be nil.
This PR moves the HEAD check in Emit to right after the call to preamble, so return no error when doing the first emit on a HEAD request.