### PR TITLE
use reflection to make writing commands nicer

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -85,6 +85,11 @@ func MakeTypedEncoder(f interface{}) func(*Request) func(io.Writer) Encoder {
 		panic("MakeTypedEncoder must return an error")
 	}
 
+	writerInt := reflect.TypeOf((*io.Writer)(nil)).Elem()
+	if t.In(0) != reflect.TypeOf(&Request{}) || !t.In(1).Implements(writerInt) {
+		panic("MakeTypedEncoder must receive a function matching func(*Request, io.Writer, ...)")
+	}
+
 	valType := t.In(2)
 
 	return MakeEncoder(func(req *Request, w io.Writer, i interface{}) error {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -91,8 +91,7 @@ var (
 					})
 				},
 				Encoders: cmds.EncoderMap{
-					cmds.Text: cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, value interface{}) error {
-						v := value.(*VersionOutput)
+					cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, v *VersionOutput) error {
 
 						if repo, ok := req.Options["repo"].(bool); ok && repo {
 							_, err := fmt.Fprintf(w, "%v\n", v.Repo)


### PR DESCRIPTION
This gives us a nice amount of type safety, and makes writing commands simpler.