### PR TITLE
[RFC] don't generate a stack trace for every command

### DIFF
--- a/cli/responseemitter.go
+++ b/cli/responseemitter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/debug"
 	"sync"
 
 	"github.com/ipfs/go-ipfs-cmdkit"
@@ -92,8 +91,6 @@ func (re *responseEmitter) Close() error {
 		return errors.New("closing closed responseemitter")
 	}
 
-	log.Debugf("err=%v exit=%v\nStack:\n%s", re.err, re.exit, debug.Stack())
-
 	re.wLock.Lock()
 	defer re.wLock.Unlock()
 
@@ -172,7 +169,6 @@ func (re *responseEmitter) Emit(v interface{}) error {
 	}
 
 	if err, ok := v.(cmdkit.Error); ok {
-		log.Warningf("fixerr %s", debug.Stack())
 		v = &err
 	}
 

--- a/cli/responseemitter.go
+++ b/cli/responseemitter.go
@@ -87,12 +87,12 @@ func (re *responseEmitter) isClosed() bool {
 }
 
 func (re *responseEmitter) Close() error {
-	if re.isClosed() {
-		return errors.New("closing closed responseemitter")
-	}
-
 	re.wLock.Lock()
 	defer re.wLock.Unlock()
+
+	if re.closed {
+		return errors.New("closing closed responseemitter")
+	}
 
 	re.ch <- re.exit
 	close(re.ch)


### PR DESCRIPTION
We can add these back if we need them but, at the very least, we shouldn't be unconditionally generating stack traces on `Close`.