### PR TITLE
return errors from cmds.Copy directly

### DIFF
--- a/responseemitter.go
+++ b/responseemitter.go
@@ -72,6 +72,10 @@ func Copy(re ResponseEmitter, res Response) error {
 			return err
 		}
 
+		if err, ok := v.(cmdkit.Error); ok {
+			return err
+		}
+
 		err = re.Emit(v)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes the issue seen in https://github.com/ipfs/go-ipfs/issues/4683 But i'm not 100% sure this is the right way.

cc @kevina, you mentioned you could help look into cmds lib issues.