### PR TITLE
handle both cmdkit.Error and *cmdkit.Error in ChanResponse

### DIFF
--- a/chan.go
+++ b/chan.go
@@ -88,6 +88,10 @@ func (r *chanResponse) Next() (interface{}, error) {
 			return nil, io.EOF
 		}
 
+		if err, ok := v.(cmdkit.Error); ok {
+			v = &err
+		}
+
 		switch val := v.(type) {
 		case *cmdkit.Error:
 			r.err = val


### PR DESCRIPTION
fixes https://github.com/ipfs/go-ipfs/issues/4683