### PR TITLE
cleaner command completion/calling

### DIFF
--- a/examples/adder/local/main.go
+++ b/examples/adder/local/main.go
@@ -31,10 +31,7 @@ func main() {
 	go func() {
 		defer close(wait)
 
-		err = adder.RootCmd.Call(req, re, nil)
-		if err != nil {
-			panic(err)
-		}
+		adder.RootCmd.Call(req, re, nil)
 	}()
 
 	// wait until command has returned and exit

--- a/http/handler.go
+++ b/http/handler.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-loggables"
@@ -158,24 +157,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	re := NewResponseEmitter(w, r.Method, req)
-	defer re.Close()
-
-	// call the command
-	err = h.root.Call(req, re, h.env)
-	if err != nil {
-		re.SetError(err, cmdkit.ErrNormal)
-		return
-	}
-
-	d := re.(Doner)
-	select {
-	case <-d.Done():
-	case <-req.Context.Done():
-		log.Errorf("waiting for http.Responseemitter to close but then %s", req.Context.Err())
-		// too late to send an error, just return
-	}
-
-	return
+	h.root.Call(req, re, h.env)
 }
 
 func sanitizedErrStr(err error) string {


### PR DESCRIPTION
**Returning errors/calling:**

Instead of having a dance where we:
  * Close the response emitter immediately if the command succeeds.
  * Return an error, call SetError, and then close the response emitter if it fails.

Just set the error from within the `Call` command and always close the response emitter.

**Doner**

Get rid of the Done channel/doner interface from the response emitter. We close the response emitter after finishing the Call *anyways* so this channel isn't necessary (anymore, at least).