### PR TITLE
fix: improve cli/run to return errors and exit code

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -12,6 +12,13 @@ import (
 	cmds "github.com/ipfs/go-ipfs-cmds"
 )
 
+// ExitError is the error used when a specific exit code needs to be returned.
+type ExitError int
+
+func (e ExitError) Error() string {
+	return fmt.Sprintf("exit code %d", int(e))
+}
+
 // Closer is a helper interface to check if the env supports closing
 type Closer interface {
 	Close()
@@ -19,7 +26,7 @@ type Closer interface {
 
 func Run(ctx context.Context, root *cmds.Command,
 	cmdline []string, stdin, stdout, stderr *os.File,
-	buildEnv cmds.MakeEnvironment, makeExecutor cmds.MakeExecutor) (int, error) {
+	buildEnv cmds.MakeEnvironment, makeExecutor cmds.MakeExecutor) error {
 
 	printErr := func(err error) {
 		fmt.Fprintf(stderr, "%s\n", err)
@@ -32,7 +39,7 @@ func Run(ctx context.Context, root *cmds.Command,
 	if timeoutStr, ok := req.Options[cmds.TimeoutOpt]; ok {
 		timeout, err := time.ParseDuration(timeoutStr.(string))
 		if err != nil {
-			return 1, err
+			return err
 		}
 		req.Context, cancel = context.WithTimeout(req.Context, timeout)
 	} else {
@@ -67,9 +74,9 @@ func Run(ctx context.Context, root *cmds.Command,
 	// AND the user requested help, print it out and exit
 	err := HandleHelp(cmdline[0], req, stdout)
 	if err == nil {
-		return 0, nil
+		return nil
 	} else if err != ErrNoHelpRequested {
-		return 1, err
+		return err
 	}
 	// no help requested, continue.
 
@@ -84,7 +91,7 @@ func Run(ctx context.Context, root *cmds.Command,
 			printHelp(false, stderr)
 		}
 
-		return 1, err
+		return err
 	}
 
 	// here we handle the cases where
@@ -92,7 +99,7 @@ func Run(ctx context.Context, root *cmds.Command,
 	// - the main command is invoked.
 	if req == nil || req.Command == nil || req.Command.Run == nil {
 		printHelp(false, stdout)
-		return 0, nil
+		return nil
 	}
 
 	cmd := req.Command
@@ -100,7 +107,7 @@ func Run(ctx context.Context, root *cmds.Command,
 	env, err := buildEnv(req.Context, req)
 	if err != nil {
 		printErr(err)
-		return 1, err
+		return err
 	}
 	if c, ok := env.(Closer); ok {
 		defer c.Close()
@@ -109,7 +116,7 @@ func Run(ctx context.Context, root *cmds.Command,
 	exctr, err := makeExecutor(req, env)
 	if err != nil {
 		printErr(err)
-		return 1, err
+		return err
 	}
 
 	var (
@@ -131,7 +138,7 @@ func Run(ctx context.Context, root *cmds.Command,
 	} else if enc, ok := cmds.Encoders[encType]; ok {
 		re, exitCh = NewResponseEmitter(stdout, stderr, enc, req)
 	} else {
-		return 1, fmt.Errorf("could not find matching encoder for enctype %#v", encType)
+		return fmt.Errorf("could not find matching encoder for enctype %#v", encType)
 	}
 
 	errCh := make(chan error, 1)
@@ -153,13 +160,13 @@ func Run(ctx context.Context, root *cmds.Command,
 			printMetaHelp(stderr)
 		}
 
-		return 1, err
+		return err
 
 	case code := <-exitCh:
 		if code != 0 {
-			return code, nil
+			return ExitError(code)
 		}
 	}
 
-	return 0, nil
+	return nil
 }


### PR DESCRIPTION
Before this was not really usable as errors were printed `Error: <error>` and the exitcode was printed instead of returned. 