### PR TITLE
prefetch required stdin arguments in CheckArguments

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.8: QmabLouZTZwhfALuBcssPvkzhbYGMb4394huT7HY4LQ6d3
+1.0.9: QmU9RepnA8QW2qtFkYUJYfWrydg3Ez7EkgoHkqt5qZgecy

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -317,115 +317,116 @@ func TestBodyArgs(t *testing.T) {
 	fstdin123 := fileToSimulateStdin(t, "stdin1\nstdin2\nstdin3")
 
 	var tcs = []struct {
-		cmd                   words
-		f                     *os.File
-		posArgs, varArgs      words
-		parseErr, bodyArgsErr error
+		cmd              words
+		f                *os.File
+		posArgs, varArgs words
+		parseErr         error
+		bodyArgs         bool
 	}{
 		{
 			cmd: words{"stdinenabled", "value1", "value2"}, f: nil,
 			posArgs: words{"value1", "value2"}, varArgs: nil,
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenabled"}, f: fstdin1,
-			posArgs: words{}, varArgs: words{"stdin1"},
-			parseErr: nil, bodyArgsErr: nil,
+			posArgs: words{"stdin1"}, varArgs: words{},
+			parseErr: nil, bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenabled", "value1"}, f: fstdin1,
 			posArgs: words{"value1"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenabled", "value1", "value2"}, f: fstdin1,
 			posArgs: words{"value1", "value2"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenabled"}, f: fstdin12,
-			posArgs: words{}, varArgs: words{"stdin1", "stdin2"},
-			parseErr: nil, bodyArgsErr: nil,
+			posArgs: words{"stdin1"}, varArgs: words{"stdin2"},
+			parseErr: nil, bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenabled"}, f: fstdin123,
-			posArgs: words{}, varArgs: words{"stdin1", "stdin2", "stdin3"},
-			parseErr: nil, bodyArgsErr: nil,
+			posArgs: words{"stdin1"}, varArgs: words{"stdin2", "stdin3"},
+			parseErr: nil, bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenabled2args", "value1", "value2"}, f: nil,
 			posArgs: words{"value1", "value2"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenabled2args", "value1"}, f: fstdin1,
 			posArgs: words{"value1"}, varArgs: words{"stdin1"},
-			parseErr: nil, bodyArgsErr: nil,
+			parseErr: nil, bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenabled2args", "value1", "value2"}, f: fstdin1,
 			posArgs: words{"value1", "value2"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenabled2args", "value1", "value2", "value3"}, f: fstdin1,
 			posArgs: words{"value1", "value2", "value3"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenabled2args", "value1"}, f: fstdin12,
 			posArgs: words{"value1"}, varArgs: words{"stdin1", "stdin2"},
-			parseErr: nil, bodyArgsErr: nil,
+			parseErr: nil, bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic", "value1"}, f: nil,
 			posArgs: words{"value1"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic"}, f: fstdin1,
-			posArgs: words{}, varArgs: words{"stdin1"},
-			parseErr: nil, bodyArgsErr: nil,
+			posArgs: words{"stdin1"}, varArgs: words{},
+			parseErr: nil, bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic", "value1"}, f: fstdin1,
 			posArgs: words{"value1"}, varArgs: words{"value1"},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic2args", "value1", "value2"}, f: nil,
 			posArgs: words{"value1", "value2"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic2args", "value1"}, f: fstdin1,
 			posArgs: words{"value1"}, varArgs: words{"stdin1"},
-			parseErr: nil, bodyArgsErr: nil,
+			parseErr: nil, bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic2args", "value1", "value2"}, f: fstdin1,
 			posArgs: words{"value1", "value2"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic2args"}, f: fstdin1,
 			posArgs: words{}, varArgs: words{},
-			parseErr: fmt.Errorf(`argument %q is required`, "a"), bodyArgsErr: nil,
+			parseErr: fmt.Errorf(`argument %q is required`, "a"), bodyArgs: true,
 		},
 		{
 			cmd: words{"stdinenablednotvariadic2args", "value1"}, f: nil,
 			posArgs: words{"value1"}, varArgs: words{},
-			parseErr: fmt.Errorf(`argument %q is required`, "b"), bodyArgsErr: nil,
+			parseErr: fmt.Errorf(`argument %q is required`, "b"), bodyArgs: true,
 		},
 		{
 			cmd: words{"noarg"}, f: fstdin1,
 			posArgs: words{}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 		{
 			cmd: words{"optionalsecond", "value1", "value2"}, f: fstdin1,
 			posArgs: words{"value1", "value2"}, varArgs: words{},
-			parseErr: nil, bodyArgsErr: fmt.Errorf("all arguments covered by positional arguments"),
+			parseErr: nil, bodyArgs: false,
 		},
 	}
 
@@ -448,16 +449,15 @@ func TestBodyArgs(t *testing.T) {
 			t.Errorf("Arguments parsed from %v are %v instead of %v", tc.cmd, req.Arguments, tc.posArgs)
 		}
 
-		s, err := req.BodyArgs()
-		if !errEq(err, tc.bodyArgsErr) {
-			t.Fatalf("calling BodyArgs() for cmd %q: expected error %q, got %q", tc.cmd, tc.bodyArgsErr, err)
-		}
-		if err != nil {
+		s := req.BodyArgs()
+		if !tc.bodyArgs {
+			if s != nil {
+				t.Fatalf("expected no BodyArgs for cmd %q", tc.cmd)
+			}
 			continue
 		}
-
 		if s == nil {
-			t.Fatal("scanner is nil, abort")
+			t.Fatalf("expected BodyArgs for cmd %q", tc.cmd)
 		}
 
 		var bodyArgs words

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -295,6 +295,18 @@ func TestBodyArgs(t *testing.T) {
 					cmdkit.StringArg("b", false, false, "another arg"),
 				},
 			},
+			"optionalstdin": {
+				Arguments: []cmdkit.Argument{
+					cmdkit.StringArg("a", true, false, "some arg"),
+					cmdkit.StringArg("b", false, false, "another arg").EnableStdin(),
+				},
+			},
+			"optionalvariadicstdin": {
+				Arguments: []cmdkit.Argument{
+					cmdkit.StringArg("a", true, false, "some arg"),
+					cmdkit.StringArg("b", false, true, "another arg").EnableStdin(),
+				},
+			},
 		},
 	}
 
@@ -360,7 +372,7 @@ func TestBodyArgs(t *testing.T) {
 		},
 		{
 			cmd: words{"stdinenabled2args", "value1"}, f: fstdin1,
-			posArgs: words{"value1"}, varArgs: words{"stdin1"},
+			posArgs: words{"value1", "stdin1"}, varArgs: words{},
 			parseErr: nil, bodyArgs: true,
 		},
 		{
@@ -375,7 +387,7 @@ func TestBodyArgs(t *testing.T) {
 		},
 		{
 			cmd: words{"stdinenabled2args", "value1"}, f: fstdin12,
-			posArgs: words{"value1"}, varArgs: words{"stdin1", "stdin2"},
+			posArgs: words{"value1", "stdin1"}, varArgs: words{"stdin2"},
 			parseErr: nil, bodyArgs: true,
 		},
 		{
@@ -400,7 +412,7 @@ func TestBodyArgs(t *testing.T) {
 		},
 		{
 			cmd: words{"stdinenablednotvariadic2args", "value1"}, f: fstdin1,
-			posArgs: words{"value1"}, varArgs: words{"stdin1"},
+			posArgs: words{"value1", "stdin1"}, varArgs: words{},
 			parseErr: nil, bodyArgs: true,
 		},
 		{
@@ -427,6 +439,36 @@ func TestBodyArgs(t *testing.T) {
 			cmd: words{"optionalsecond", "value1", "value2"}, f: fstdin1,
 			posArgs: words{"value1", "value2"}, varArgs: words{},
 			parseErr: nil, bodyArgs: false,
+		},
+		{
+			cmd: words{"optionalstdin", "value1"}, f: fstdin1,
+			posArgs: words{"value1"}, varArgs: words{"stdin1"},
+			parseErr: nil, bodyArgs: true,
+		},
+		{
+			cmd: words{"optionalstdin", "value1"}, f: nil,
+			posArgs: words{"value1"}, varArgs: words{},
+			parseErr: nil, bodyArgs: false,
+		},
+		{
+			cmd: words{"optionalstdin"}, f: fstdin1,
+			posArgs: words{"value1"}, varArgs: words{},
+			parseErr: fmt.Errorf(`argument %q is required`, "a"), bodyArgs: false,
+		},
+		{
+			cmd: words{"optionalvariadicstdin", "value1"}, f: nil,
+			posArgs: words{"value1"}, varArgs: words{},
+			parseErr: nil, bodyArgs: false,
+		},
+		{
+			cmd: words{"optionalvariadicstdin", "value1"}, f: fstdin1,
+			posArgs: words{"value1"}, varArgs: words{"stdin1"},
+			parseErr: nil, bodyArgs: true,
+		},
+		{
+			cmd: words{"optionalvariadicstdin", "value1"}, f: fstdin12,
+			posArgs: words{"value1"}, varArgs: words{"stdin1", "stdin2"},
+			parseErr: nil, bodyArgs: true,
 		},
 	}
 

--- a/command.go
+++ b/command.go
@@ -244,7 +244,7 @@ func (c *Command) CheckArguments(req *Request) error {
 	}
 
 	// iterate over the arg definitions
-	valueIndex := 0 // the index of the current value (in `args`)
+	requiredStringArgs := 0 // number of required string arguments
 	for _, argDef := range req.Command.Arguments {
 		// Is this a string?
 		if argDef.Type != cmdkit.ArgString {
@@ -257,9 +257,10 @@ func (c *Command) CheckArguments(req *Request) error {
 			// Yes, we're all done.
 			break
 		}
+		requiredStringArgs++
 
-		// Do we have this required string argument?
-		if valueIndex < len(req.Arguments) {
+		// Do we have enough string arguments?
+		if requiredStringArgs <= len(req.Arguments) {
 			// all good
 			continue
 		}

--- a/command.go
+++ b/command.go
@@ -225,7 +225,7 @@ func (c *Command) CheckArguments(req *Request) error {
 	}
 
 	lastArg := c.Arguments[len(c.Arguments)-1]
-	if req.bodyArgs == nil &&
+	if req.bodyArgs == nil && // check this as we can end up calling CheckArguments multiple times. See #80.
 		lastArg.SupportsStdin &&
 		lastArg.Type == cmdkit.ArgString &&
 		req.Files != nil {

--- a/command.go
+++ b/command.go
@@ -9,8 +9,10 @@ output to the user, including text, JSON, and XML marshallers.
 package cmds
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/ipfs/go-ipfs-cmdkit"
@@ -162,55 +164,67 @@ func (c *Command) GetOptions(path []string) (map[string]cmdkit.Option, error) {
 	return optionsMap, nil
 }
 
+// CheckArguments checks that we have all the required string arguments, loading
+// any from stdin if necessary.
 func (c *Command) CheckArguments(req *Request) error {
-	args := req.Arguments
+	if len(c.Arguments) == 0 {
+		return nil
+	}
 
-	// count required argument definitions
-	numRequired := 0
-	for _, argDef := range c.Arguments {
-		if argDef.Required {
-			numRequired++
+	lastArg := c.Arguments[len(c.Arguments)-1]
+	if req.bodyArgs == nil &&
+		lastArg.SupportsStdin &&
+		lastArg.Type == cmdkit.ArgString &&
+		req.Files != nil {
+
+		fi, err := req.Files.NextFile()
+		switch err {
+		case io.EOF:
+		case nil:
+			req.bodyArgs = bufio.NewScanner(fi)
+			// Can't pass files and stdin arguments.
+			req.Files = nil
+		default:
+			// io error.
+			return err
 		}
 	}
 
 	// iterate over the arg definitions
 	valueIndex := 0 // the index of the current value (in `args`)
-	for i, argDef := range c.Arguments {
-		// skip optional argument definitions if there aren't
-		// sufficient remaining values
-		if len(args)-valueIndex <= numRequired && !argDef.Required ||
-			argDef.Type == cmdkit.ArgFile {
+	for _, argDef := range req.Command.Arguments {
+		// Is this a string?
+		if argDef.Type != cmdkit.ArgString {
+			// No, skip it.
 			continue
 		}
 
-		// the value for this argument definition. can be nil if it
-		// wasn't provided by the caller
-		v, found := "", false
-		if valueIndex < len(args) {
-			v = args[valueIndex]
-			found = true
-			valueIndex++
+		// No more required arguments?
+		if !argDef.Required {
+			// Yes, we're all done.
+			break
 		}
 
-		// in the case of a non-variadic required argument that supports stdin
-		if !found && len(c.Arguments)-1 == i && argDef.SupportsStdin {
-			found = true
+		// Do we have this required string argument?
+		if valueIndex < len(req.Arguments) {
+			// all good
+			continue
 		}
 
-		err := checkArgValue(v, found, argDef)
-		if err != nil {
-			return err
-		}
-
-		// any additional values are for the variadic arg definition
-		if argDef.Variadic && valueIndex < len(args)-1 {
-			for _, val := range args[valueIndex:] {
-				err := checkArgValue(val, true, argDef)
-				if err != nil {
-					return err
-				}
+		// Can we get it from stdin?
+		if argDef.SupportsStdin && req.bodyArgs != nil {
+			if req.bodyArgs.Scan() {
+				// Found it!
+				req.Arguments = append(req.Arguments, req.bodyArgs.Text())
+				continue
 			}
+			// Nope! Maybe we had a read error?
+			if err := req.bodyArgs.Err(); err != nil {
+				return err
+			}
+			// No, just missing.
 		}
+		return fmt.Errorf("argument %q is required", argDef.Name)
 	}
 
 	return nil
@@ -233,20 +247,6 @@ func (c *Command) ProcessHelp() {
 			ht.LongDescription = ht.ShortDescription
 		}
 	})
-}
-
-// checkArgValue returns an error if a given arg value is not valid for the
-// given Argument
-func checkArgValue(v string, found bool, def cmdkit.Argument) error {
-	if def.Variadic && def.SupportsStdin {
-		return nil
-	}
-
-	if !found && def.Required {
-		return fmt.Errorf("argument %q is required", def.Name)
-	}
-
-	return nil
 }
 
 func ClientError(msg string) error {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   "license": "MIT",
   "name": "go-ipfs-cmds",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.8"
+  "version": "1.0.9"
 }
 


### PR DESCRIPTION
Also:

* Make it easier to actually use ParseBodyArguments. Now it only returns an error when something actually goes wrong.
* Add a function for validating a command tree (to be run from a test case).