### PR TITLE
Remove calls to SetError when returning error from Run.

### DIFF
--- a/examples/adder/cmd.go
+++ b/examples/adder/cmd.go
@@ -35,7 +35,6 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 
@@ -58,7 +57,6 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 
@@ -102,7 +100,6 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 
@@ -168,7 +165,6 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 


### PR DESCRIPTION
Cleanup from #87.

The remaining calls to `SetError` in the adder example should have been removed.