### PR TITLE
Handle ErrNotFound.

### DIFF
--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -121,6 +121,15 @@ var (
 					}),
 				},
 			},
+			"notfound": &cmds.Command{
+				Helptext: cmdkit.HelpText{
+					Tagline: "Fail with 404",
+				},
+				Type: VersionOutput{},
+				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) {
+					re.SetError(cmdkit.Error{Message: "Not found", Code: cmdkit.ErrNotFound}, cmdkit.ErrNotFound)
+				},
+			},
 		},
 	}
 )

--- a/http/reforigin_test.go
+++ b/http/reforigin_test.go
@@ -355,3 +355,30 @@ func TestEncoding(t *testing.T) {
 		tc.test(t)
 	}
 }
+
+func TestNotFound(t *testing.T) {
+	gtc := func(enc, contentType string) httpTestCase {
+		code := http.StatusNotFound
+		path := fmt.Sprintf("/notfound?%v=%v", cmds.EncShort, enc)
+
+		return httpTestCase{
+			Method:       "GET",
+			Path:         path,
+			Origin:       "http://localhost",
+			AllowOrigins: []string{"*"},
+			ReqHeaders: map[string]string{
+				"Access-Control-Request-Method": "GET",
+			},
+			//ResHeaders: hdrs,
+			Code: code,
+		}
+	}
+
+	tcs := []httpTestCase{
+		gtc(cmds.JSON, applicationJson),
+	}
+
+	for _, tc := range tcs {
+		tc.test(t)
+	}
+}

--- a/http/responseemitter.go
+++ b/http/responseemitter.go
@@ -148,6 +148,11 @@ func (re *responseEmitter) Close() error {
 }
 
 func (re *responseEmitter) SetError(v interface{}, errType cmdkit.ErrorType) {
+	if errType == cmdkit.ErrNotFound {
+		re.w.WriteHeader(http.StatusNotFound)
+		re.Close()
+		return
+	}
 	err := re.Emit(&cmdkit.Error{Message: fmt.Sprint(v), Code: errType})
 	if err != nil {
 		log.Debug("http.SetError err=", err)


### PR DESCRIPTION
Addresses #90.

This seems to work, but it's possible I'm missing a subtlety.

The tests are not great. For the sake of simplicity, I piggy-backed on existing tests that were already checking response codes of a constructed HTTP server. It wouldn't be too hard to tease them further apart while still keeping the current test implementation effectively the same. Or, if there's a better approach altogether, please let me know. This test was the one I used to develop/verify the fix, so I'm including as-is for review.