### PR TITLE
Use existing code when setting error from returned error.

### DIFF
--- a/command.go
+++ b/command.go
@@ -106,7 +106,7 @@ func (c *Command) Call(req *Request, re ResponseEmitter, env Environment) {
 
 	err = cmd.Run(req, re, env)
 	if err != nil {
-		re.SetError(err, cmdkit.ErrNormal)
+		SetErrorWithDefaultType(re, err)
 	}
 }
 

--- a/executor.go
+++ b/executor.go
@@ -107,7 +107,7 @@ func (x *executor) Execute(req *Request, re ResponseEmitter, env Environment) (e
 	}()
 	err = cmd.Run(req, re, env)
 	if err != nil {
-		re.SetError(err, cmdkit.ErrNormal)
+		SetErrorWithDefaultType(re, err)
 	}
 	return nil
 }

--- a/responseemitter.go
+++ b/responseemitter.go
@@ -78,3 +78,12 @@ func Copy(re ResponseEmitter, res Response) error {
 		}
 	}
 }
+
+func SetErrorWithDefaultType(re ResponseEmitter, err error) {
+	switch err := err.(type) {
+	case cmdkit.Error:
+		re.SetError(err, err.Code)
+	default:
+		re.SetError(err, cmdkit.ErrNormal)
+	}
+}


### PR DESCRIPTION
This PR adds handling for non-`ErrNormal` error types returned from `Run`.

It is unclear to me why 7 commits are showing up in this PR. Presumably it's related to shenanigans with the feat/filecoin branch.

The last commit is a child of the Gx release 1.1.1, which is also the current head of `feat/filecoin`. Those are the effective changes introduced here.