### PR TITLE
Add link traversal option

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -10,10 +10,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ipfs/go-ipfs-cmds"
-
 	osh "github.com/Kubuxu/go-os-helper"
 	"github.com/ipfs/go-ipfs-cmdkit"
+	"github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs-files"
 	logging "github.com/ipfs/go-log"
 )
@@ -265,6 +264,12 @@ func parseArgs(req *cmds.Request, root *cmds.Command, stdin *os.File) error {
 					fpath = stdin.Name()
 					file = files.NewReaderFile("", fpath, r, nil)
 				} else {
+					if derefArgs, _ := req.Options[cmds.DerefLong].(bool); derefArgs {
+						var err error // don't shadow fpath
+						if fpath, err = filepath.EvalSymlinks(fpath); err != nil {
+							return err
+						}
+					}
 					nf, err := appendFile(fpath, argDef, isRecursive(req), isHidden(req))
 					if err != nil {
 						return err

--- a/opts.go
+++ b/opts.go
@@ -14,10 +14,12 @@ const (
 	TimeoutOpt   = "timeout"
 	OptShortHelp = "h"
 	OptLongHelp  = "help"
+	DerefLong    = "dereference-args"
 )
 
 // options that are used by this package
 var OptionEncodingType = cmdkit.StringOption(EncLong, EncShort, "The encoding type the output should be encoded with (json, xml, or text)").WithDefault("text")
-var OptionRecursivePath = cmdkit.BoolOption(RecLong, RecShort, "Add directory paths recursively").WithDefault(false)
+var OptionRecursivePath = cmdkit.BoolOption(RecLong, RecShort, "Add directory paths recursively")
 var OptionStreamChannels = cmdkit.BoolOption(ChanOpt, "Stream channel output")
-var OptionTimeout = cmdkit.StringOption(TimeoutOpt, "set a global timeout on the command")
+var OptionTimeout = cmdkit.StringOption(TimeoutOpt, "Set a global timeout on the command")
+var OptionDerefArgs = cmdkit.BoolOption(DerefLong, "Symlinks supplied in arguments are dereferenced")


### PR DESCRIPTION
This allows us to follow filesystem links (symlinks, junctions, etc.).
The logic should be good but I need a suggestions on what the flag(s) should be. `traverse-links` is a placeholder.

This is needed in `go-ipfs` so that we can traverse the link and add the target instead of adding the link itself.