### PR TITLE
Rezero struct between each decode

### DIFF
--- a/http/response.go
+++ b/http/response.go
@@ -66,11 +66,13 @@ func (res *Response) RawNext() (interface{}, error) {
 		}
 	}
 
-	valueType := reflect.TypeOf(res.req.Command.Type)
-	if valueType.Kind() == reflect.Ptr {
-		valueType = valueType.Elem()
+	var value interface{}
+	if valueType := reflect.TypeOf(res.req.Command.Type); valueType != nil {
+		if valueType.Kind() == reflect.Ptr {
+			valueType = valueType.Elem()
+		}
+		value = reflect.New(valueType).Interface()
 	}
-	value := reflect.New(valueType).Interface()
 	m := &cmds.MaybeError{Value: value}
 	err := res.dec.Decode(m)
 

--- a/http/response.go
+++ b/http/response.go
@@ -59,11 +59,10 @@ func (res *Response) RawNext() (interface{}, error) {
 	if res.dec == nil {
 		if res.rr == nil {
 			return nil, io.EOF
-		} else {
-			rr := res.rr
-			res.rr = nil
-			return rr, nil
 		}
+		rr := res.rr
+		res.rr = nil
+		return rr, nil
 	}
 
 	var value interface{}

--- a/http/response.go
+++ b/http/response.go
@@ -66,7 +66,11 @@ func (res *Response) RawNext() (interface{}, error) {
 		}
 	}
 
-	value := reflect.New(reflect.TypeOf(res.req.Command.Type).Elem()).Interface()
+	valueType := reflect.TypeOf(res.req.Command.Type)
+	if valueType.Kind() == reflect.Ptr {
+		valueType = valueType.Elem()
+	}
+	value := reflect.New(valueType).Interface()
 	m := &cmds.MaybeError{Value: value}
 	err := res.dec.Decode(m)
 

--- a/http/response.go
+++ b/http/response.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ipfs/go-ipfs-cmdkit"
 	"github.com/ipfs/go-ipfs-cmds"
+	"reflect"
 )
 
 var (
@@ -65,7 +66,8 @@ func (res *Response) RawNext() (interface{}, error) {
 		}
 	}
 
-	m := &cmds.MaybeError{Value: res.req.Command.Type}
+	value := reflect.New(reflect.TypeOf(res.req.Command.Type).Elem()).Interface()
+	m := &cmds.MaybeError{Value: value}
 	err := res.dec.Decode(m)
 
 	// last error was sent as value, now we get the same error from the headers. ignore and EOF!

--- a/http/response_test.go
+++ b/http/response_test.go
@@ -72,7 +72,7 @@ func TestRawNextDecodesIntoNewStruct(t *testing.T) {
 	}
 
 	tv2 := v2.(*testResponseType)
-	if tv2.a != 4 {
+	if tv2.a != 3 {
 		t.Errorf("tv2.a is %#v, expected 3", tv2.a)
 	}
 	if tv2.b != 0 {

--- a/http/response_test.go
+++ b/http/response_test.go
@@ -1,0 +1,81 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-ipfs-cmds"
+)
+
+type testResponseType struct {
+	a int
+	b int
+}
+
+type testDecoder struct {
+	a *int
+	b *int
+}
+
+func (td *testDecoder) Decode(value interface{}) error {
+	me := value.(*cmds.MaybeError)
+	o := me.Value.(*testResponseType)
+
+	if td.a != nil {
+		o.a = *td.a
+	}
+
+	if td.b != nil {
+		o.b = *td.b
+	}
+
+	return nil
+}
+
+func TestRawNextDecodesIntoNewStruct(t *testing.T) {
+	a1 := 1
+	b1 := 2
+	testCommand := &cmds.Command{
+		Type: &testResponseType{},
+	}
+	decoder := &testDecoder{
+		a: &a1,
+		b: &b1,
+	}
+	r := &cmds.Request{
+		Command: testCommand,
+	}
+	response := &Response{
+		req: r,
+		dec: decoder,
+	}
+
+	v, err := response.RawNext()
+	if err != nil {
+		t.Fatal("error decoding response", err)
+	}
+
+	tv := v.(*testResponseType)
+	if tv.a != 1 {
+		t.Errorf("tv.a is %#v, expected 1", tv.a)
+	}
+	if tv.b != 2 {
+		t.Errorf("tv.b is %#v, expected 2", tv.b)
+	}
+
+	a2 := 3
+	decoder.a = &a2
+	decoder.b = nil
+
+	v2, err := response.RawNext()
+	if err != nil {
+		t.Fatal("error decoding response", err)
+	}
+
+	tv2 := v2.(*testResponseType)
+	if tv2.a != 4 {
+		t.Errorf("tv2.a is %#v, expected 3", tv2.a)
+	}
+	if tv2.b != 0 {
+		t.Errorf("tv.b is %#v, expected it to be reset to 0", tv2.b)
+	}
+}


### PR DESCRIPTION
## Problem

When the server returns multiple values, the client decodes the results into the Command.Type struct. It does not reset this struct, so any property set in the first struct and not overridden in the second will appear in the second value as it is emitted by the client. For example the server responds with the following new line delimited JSON:

```JSON
{"a": 1}
{"a": 1, "b": 2}
{"a": 1}
```
for a command whose Type is:

```GO
type CmdType struct {
  a int;
  b int;
}
```

We would expect the client to output:
```JSON
{"a": 1, "b": 0}
{"a": 1, "b": 2}
{"a": 1, "b": 0}
```
but it actually outputs:
```JSON
{"a": 1, "b": 0}
{"a": 1, "b": 2}
{"a": 1, "b": 2}
```
Because `b` isn't set in the last result, it keeps the value `2` from the previous result.

## Solution

The proposed solution uses the reflection library to instantiate new instance of the given type for each pass through decode.