### PR TITLE
Change PostRun signature

### DIFF
--- a/command.go
+++ b/command.go
@@ -28,7 +28,7 @@ var log = logging.Logger("cmds")
 type Function func(*Request, ResponseEmitter, Environment)
 
 // PostRunMap is the map used in Command.PostRun.
-type PostRunMap map[PostRunType]func(*Request, ResponseEmitter) ResponseEmitter
+type PostRunMap map[PostRunType]func(Response, ResponseEmitter) error
 
 // Command is a runnable command, with input arguments and options (flags).
 // It can also have Subcommands, to group units of work into sets.

--- a/examples/adder/cmd.go
+++ b/examples/adder/cmd.go
@@ -114,42 +114,34 @@ var RootCmd = &cmds.Command{
 			},
 			Type: &AddStatus{},
 			PostRun: cmds.PostRunMap{
-				cmds.CLI: func(req *cmds.Request, re cmds.ResponseEmitter) cmds.ResponseEmitter {
-					reNext, res := cmds.NewChanResponsePair(req)
+				cmds.CLI: func(res cmds.Response, re cmds.ResponseEmitter) error {
+					defer re.Close()
+					defer fmt.Println()
 
-					go func() {
-						defer re.Close()
-						defer fmt.Println()
+					// length of line at last iteration
+					var lastLen int
 
-						// length of line at last iteration
-						var lastLen int
-
-						for {
-							v, err := res.Next()
-							if err == io.EOF {
-								return
-							}
-							if err == cmds.ErrRcvdError {
-								fmt.Println("\nreceived error:", res.Error())
-								return
-							}
-							if err != nil {
-								fmt.Println("\nerror:", err)
-								return
-							}
-
-							fmt.Print("\r" + strings.Repeat(" ", lastLen))
-
-							s := v.(*AddStatus)
-							if s.Left > 0 {
-								lastLen, _ = fmt.Printf("\rcalculation sum... current: %d; left: %d", s.Current, s.Left)
-							} else {
-								lastLen, _ = fmt.Printf("\rsum is %d.", s.Current)
-							}
+					for {
+						v, err := res.Next()
+						if err == io.EOF {
+							return nil
 						}
-					}()
+						if err == cmds.ErrRcvdError {
+							return res.Error()
+						}
+						if err != nil {
+							return err
+						}
 
-					return reNext
+						fmt.Print("\r" + strings.Repeat(" ", lastLen))
+
+						s := v.(*AddStatus)
+						if s.Left > 0 {
+							lastLen, _ = fmt.Printf("\rcalculation sum... current: %d; left: %d", s.Current, s.Left)
+						} else {
+							lastLen, _ = fmt.Printf("\rsum is %d.", s.Current)
+						}
+					}
 				},
 			},
 		},
@@ -179,50 +171,42 @@ var RootCmd = &cmds.Command{
 			},
 			Type: &AddStatus{},
 			PostRun: cmds.PostRunMap{
-				cmds.CLI: func(req *cmds.Request, re cmds.ResponseEmitter) cmds.ResponseEmitter {
-					reNext, res := cmds.NewChanResponsePair(req)
+				cmds.CLI: func(res cmds.Response, re cmds.ResponseEmitter) error {
 					clire := re.(cli.ResponseEmitter)
 
-					go func() {
-						defer re.Close()
-						defer fmt.Println()
+					defer re.Close()
+					defer fmt.Println()
 
-						// length of line at last iteration
-						var lastLen int
+					// length of line at last iteration
+					var lastLen int
 
-						var exit int
-						defer func() {
-							clire.Exit(exit)
-						}()
-
-						for {
-							v, err := res.Next()
-							if err == io.EOF {
-								return
-							}
-							if err == cmds.ErrRcvdError {
-								fmt.Println("\nreceived error:", res.Error())
-								break
-							}
-							if err != nil {
-								fmt.Println("\nerror:", err)
-								break
-							}
-
-							fmt.Print("\r" + strings.Repeat(" ", lastLen))
-
-							s := v.(*AddStatus)
-							if s.Left > 0 {
-								lastLen, _ = fmt.Printf("\rcalculation sum... current: %d; left: %d", s.Current, s.Left)
-							} else {
-								lastLen, _ = fmt.Printf("\rsum is %d.", s.Current)
-								exit = s.Current
-							}
-						}
-
+					var exit int
+					defer func() {
+						clire.Exit(exit)
 					}()
 
-					return reNext
+					for {
+						v, err := res.Next()
+						if err == io.EOF {
+							return nil
+						}
+						if err == cmds.ErrRcvdError {
+							return res.Error()
+						}
+						if err != nil {
+							return err
+						}
+
+						fmt.Print("\r" + strings.Repeat(" ", lastLen))
+
+						s := v.(*AddStatus)
+						if s.Left > 0 {
+							lastLen, _ = fmt.Printf("\rcalculation sum... current: %d; left: %d", s.Current, s.Left)
+						} else {
+							lastLen, _ = fmt.Printf("\rsum is %d.", s.Current)
+							exit = s.Current
+						}
+					}
 				},
 			},
 		},

--- a/examples/adder/local/main.go
+++ b/examples/adder/local/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/ipfs/go-ipfs-cmds/examples/adder"
@@ -23,7 +24,19 @@ func main() {
 	re, retCh := cli.NewResponseEmitter(os.Stdout, os.Stderr, req.Command.Encoders["Text"], req)
 
 	if pr, ok := req.Command.PostRun[cmds.CLI]; ok {
-		re = pr(req, re)
+		var (
+			res   cmds.Response
+			lower = re
+		)
+
+		re, res = cmds.NewChanResponsePair(req)
+
+		go func() {
+			err := pr(res, lower)
+			if err != nil {
+				fmt.Println("error: ", err)
+			}
+		}()
 	}
 
 	wait := make(chan struct{})

--- a/examples/adder/remote/client/main.go
+++ b/examples/adder/remote/client/main.go
@@ -33,14 +33,16 @@ func main() {
 	// create an emitter
 	re, retCh := cli.NewResponseEmitter(os.Stdout, os.Stderr, req.Command.Encoders["Text"], req)
 
-	if pr, ok := req.Command.PostRun[cmds.CLI]; ok {
-		re = pr(req, re)
-	}
-
 	wait := make(chan struct{})
 	// copy received result into cli emitter
 	go func() {
-		err = cmds.Copy(re, res)
+		var err error
+
+		if pr, ok := req.Command.PostRun[cmds.CLI]; ok {
+			err = pr(res, re)
+		} else {
+			err = cmds.Copy(re, res)
+		}
 		if err != nil {
 			re.SetError(err, cmdkit.ErrNormal|cmdkit.ErrFatal)
 		}

--- a/examples/adder/remote/server/main.go
+++ b/examples/adder/remote/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	nethttp "net/http"
 
 	"github.com/ipfs/go-ipfs-cmds/examples/adder"
@@ -8,8 +9,14 @@ import (
 	http "github.com/ipfs/go-ipfs-cmds/http"
 )
 
+type env struct{}
+
+func (env) Context() context.Context {
+	return context.TODO()
+}
+
 func main() {
-	h := http.NewHandler(nil, adder.RootCmd, http.NewServerConfig())
+	h := http.NewHandler(env{}, adder.RootCmd, http.NewServerConfig())
 
 	// create http rpc server
 	err := nethttp.ListenAndServe(":6798", h)

--- a/http/client.go
+++ b/http/client.go
@@ -97,20 +97,20 @@ func (c *client) Execute(req *cmds.Request, re cmds.ResponseEmitter, env cmds.En
 		}
 	}
 
-	if cmd.PostRun != nil {
-		if typer, ok := re.(interface {
-			Type() cmds.PostRunType
-		}); ok && cmd.PostRun[typer.Type()] != nil {
-			re = cmd.PostRun[typer.Type()](req, re)
-		}
-	}
-
 	res, err := c.Send(req)
 	if err != nil {
 		if isConnRefused(err) {
 			err = ErrAPINotRunning
 		}
 		return err
+	}
+
+	if cmd.PostRun != nil {
+		if typer, ok := re.(interface {
+			Type() cmds.PostRunType
+		}); ok && cmd.PostRun[typer.Type()] != nil {
+			return cmd.PostRun[typer.Type()](res, re)
+		}
 	}
 
 	return cmds.Copy(re, res)


### PR DESCRIPTION
This change set changes the signature of PostRun function from
```go
func(*Request, ResponseEmitter) ResponseEmitter
```
to
```go
func(Response, ResponseEmitter) error
```
(Note that `Response` lets the callee access the request as well)

Before, every PostRun function had the same boilerplate: first create a new (Reponse, ResponseEmitter) pair, read the response in a goroutine and write to the responseemitter we were passed, and outside the goroutine return the ResponseEmitter from the pair.

This PR moves all that boilerplate into the cmds library, so the user just writes what used to be inside the goroutine into the PostRun function and, when an error occurs, just returns it.
The core change is in [executor.go](#diff-58bccd1b2cfaf06d4d4ac893e4712c88R84), but I also had to change all the tests and examples.