### PR TITLE
[WIP] Change SetError to CloseWithError

### DIFF
--- a/chan.go
+++ b/chan.go
@@ -4,42 +4,53 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime/debug"
+	"sync"
 
 	"github.com/ipfs/go-ipfs-cmdkit"
 )
 
+func EmitChan(re ResponseEmitter, ch chan interface{}) error {
+	for v := range ch {
+		err := re.Emit(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func NewChanResponsePair(req *Request) (ResponseEmitter, Response) {
 	ch := make(chan interface{})
 	wait := make(chan struct{})
-	done := make(chan struct{})
 
 	r := &chanResponse{
 		req:  req,
 		ch:   ch,
 		wait: wait,
-		done: done,
 	}
 
-	re := &chanResponseEmitter{
-		ch:     ch,
-		length: &r.length,
-		wait:   wait,
-		done:   done,
-	}
+	re := (*chanResponseEmitter)(r)
 
 	return re, r
 }
 
 type chanResponse struct {
+	l   sync.Mutex
 	req *Request
-
-	err    *cmdkit.Error
-	length uint64
 
 	// wait makes header requests block until the body is sent
 	wait chan struct{}
-	ch   <-chan interface{}
-	done chan<- struct{}
+	// waitOnce makes sure we only close wait once
+	waitOnce sync.Once
+
+	// ch is used to send values from emitter to response
+	ch chan interface{}
+
+	emitted bool
+	err     *cmdkit.Error
+	length  uint64
 }
 
 func (r *chanResponse) Request() *Request {
@@ -70,8 +81,21 @@ func (r *chanResponse) Length() uint64 {
 	return r.length
 }
 
+func (re *chanResponse) Head() Head {
+	<-re.wait
+
+	return Head{
+		Len: re.length,
+		Err: re.err,
+	}
+}
+
 func (r *chanResponse) Next() (interface{}, error) {
 	if r == nil {
+		if r.err != nil {
+			return nil, r.err
+		}
+
 		return nil, io.EOF
 	}
 
@@ -82,27 +106,42 @@ func (r *chanResponse) Next() (interface{}, error) {
 		ctx = context.Background()
 	}
 
+	err := func() error {
+		if r.ch == nil {
+			return io.EOF
+		}
+
+		return nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
 	select {
 	case v, ok := <-r.ch:
 		if !ok {
+			if r.err != nil {
+				return nil, r.err
+			}
+
 			return nil, io.EOF
 		}
 
-		if err, ok := v.(cmdkit.Error); ok {
+		if err, ok := v.(*cmdkit.Error); ok {
 			v = &err
 		}
 
 		switch val := v.(type) {
 		case *cmdkit.Error:
-			r.err = val
-			return nil, ErrRcvdError
+			// TODO keks remove logging
+			log.Error("unexpected error value:", val)
+			return val, nil
 		case Single:
 			return val.Value, nil
 		default:
 			return v, nil
 		}
 	case <-ctx.Done():
-		close(r.done)
 		return nil, ctx.Err()
 	}
 
@@ -128,28 +167,23 @@ func (r *chanResponse) RawNext() (interface{}, error) {
 
 		return nil, io.EOF
 	case <-ctx.Done():
-		close(r.done)
 		return nil, ctx.Err()
 	}
 
 }
 
-type chanResponseEmitter struct {
-	ch   chan<- interface{}
-	wait chan struct{}
-	done <-chan struct{}
-
-	length *uint64
-	err    **cmdkit.Error
-
-	emitted bool
-}
+type chanResponseEmitter chanResponse
 
 func (re *chanResponseEmitter) Emit(v interface{}) error {
+	if e, ok := v.(*cmdkit.Error); ok {
+		log.Errorf("unexpected error value emitted: %s at\n%s", e.Error(), debug.Stack())
+	}
+
+	// channel emission iteration
+	// TODO remove this
 	if ch, ok := v.(chan interface{}); ok {
 		v = (<-chan interface{})(ch)
 	}
-
 	if ch, isChan := v.(<-chan interface{}); isChan {
 		for v = range ch {
 			err := re.Emit(v)
@@ -160,54 +194,61 @@ func (re *chanResponseEmitter) Emit(v interface{}) error {
 		return nil
 	}
 
-	re.emitted = true
-	if re.wait != nil {
+	// unblock Length(), Error() and Head()
+	re.waitOnce.Do(func() {
 		close(re.wait)
-		re.wait = nil
-	}
+	})
+
+	re.l.Lock()
+	defer re.l.Unlock()
 
 	if re.ch == nil {
 		return fmt.Errorf("emitter closed")
 	}
 
 	if _, ok := v.(Single); ok {
-		defer re.Close()
+		defer re.close()
 	}
+
+	ctx := re.req.Context
+
+	fmt.Println("emitting", re.ch == nil)
 
 	select {
 	case re.ch <- v:
 		return nil
-	case <-re.done:
-		return context.Canceled
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
-func (re *chanResponseEmitter) SetError(v interface{}, errType cmdkit.ErrorType) {
-	err := re.Emit(&cmdkit.Error{Message: fmt.Sprint(v), Code: errType})
-	if err != nil {
-		panic(err)
+func (re *chanResponseEmitter) CloseWithError(err error) error {
+	re.l.Lock()
+	defer re.l.Unlock()
+
+	e, ok := err.(*cmdkit.Error)
+	if !ok {
+		e = &cmdkit.Error{Message: err.Error()}
 	}
+
+	re.err = e
+	return re.close()
 }
 
 func (re *chanResponseEmitter) SetLength(l uint64) {
+	re.l.Lock()
+	defer re.l.Unlock()
+
 	// don't change value after emitting
 	if re.emitted {
 		return
 	}
 
-	*re.length = l
+	re.length = l
 }
 
-func (re *chanResponseEmitter) Head() Head {
-	<-re.wait
-
-	return Head{
-		Len: *re.length,
-		Err: *re.err,
-	}
-}
-
-func (re *chanResponseEmitter) Close() error {
+func (re *chanResponseEmitter) close() error {
+	fmt.Printf("close called %p\n", re)
 	if re.ch == nil {
 		return nil
 	}
@@ -216,4 +257,11 @@ func (re *chanResponseEmitter) Close() error {
 	re.ch = nil
 
 	return nil
+}
+
+func (re *chanResponseEmitter) Close() error {
+	re.l.Lock()
+	defer re.l.Unlock()
+
+	return re.close()
 }

--- a/chan.go
+++ b/chan.go
@@ -26,9 +26,9 @@ func NewChanResponsePair(req *Request) (ResponseEmitter, Response) {
 	wait := make(chan struct{})
 
 	r := &chanResponse{
-		req:  req,
-		ch:   ch,
-		wait: wait,
+		req:    req,
+		ch:     ch,
+		wait:   wait,
 		closed: make(chan struct{}),
 	}
 
@@ -54,7 +54,7 @@ type chanResponse struct {
 	length  uint64
 
 	closeOnce sync.Once
-	closed chan struct{}
+	closed    chan struct{}
 }
 
 func (r *chanResponse) Request() *Request {
@@ -76,7 +76,7 @@ func (r *chanResponse) Error() *cmdkit.Error {
 		log.Warning("chan emitter error is nil after close; undefined state! returning EOF")
 		return &cmdkit.Error{Message: "EOF"}
 	}
-	
+
 	if e, ok := r.err.(cmdkit.Error); ok {
 		return &e
 	}
@@ -256,16 +256,16 @@ func (re *chanResponseEmitter) CloseWithError(err error) error {
 func (re *chanResponseEmitter) closeWithError(err error) error {
 	fmt.Printf("close called %p with error %v\n", re, err)
 
-	if e, ok := err.(cmdkit.Error);ok {
+	if e, ok := err.(cmdkit.Error); ok {
 		err = &e
 	}
 
-/*
-	e, ok := err.(*cmdkit.Error)
-	if !ok {
-		e = &cmdkit.Error{Message: err.Error()}
-	}
-*/
+	/*
+		e, ok := err.(*cmdkit.Error)
+		if !ok {
+			e = &cmdkit.Error{Message: err.Error()}
+		}
+	*/
 	re.closeOnce.Do(func() {
 		re.err = err
 		close(re.ch)

--- a/cli/responseemitter_test.go
+++ b/cli/responseemitter_test.go
@@ -2,10 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	//"io"
 	"testing"
 
-	"github.com/ipfs/go-ipfs-cmdkit"
+	//"github.com/ipfs/go-ipfs-cmdkit"
 	"github.com/ipfs/go-ipfs-cmds"
 )
 
@@ -15,14 +16,14 @@ type writeCloser struct {
 
 func (wc writeCloser) Close() error { return nil }
 
-type tcSetError struct {
+type tcCloseWithError struct {
 	stdout, stderr     *bytes.Buffer
 	exStdout, exStderr string
 	exExit             int
 	f                  func(re ResponseEmitter, t *testing.T)
 }
 
-func (tc tcSetError) Run(t *testing.T) {
+func (tc tcCloseWithError) Run(t *testing.T) {
 	req := &cmds.Request{}
 
 	cmdsre, exitCh := NewResponseEmitter(tc.stdout, tc.stderr, nil, req)
@@ -47,9 +48,9 @@ func (tc tcSetError) Run(t *testing.T) {
 	t.Logf("stderr:\n---\n%s---\n", tc.stderr.Bytes())
 }
 
-func TestSetError(t *testing.T) {
-	tcs := []tcSetError{
-		tcSetError{
+func TestCloseWithError(t *testing.T) {
+	tcs := []tcCloseWithError{
+		tcCloseWithError{
 			stdout:   bytes.NewBuffer(nil),
 			stderr:   bytes.NewBuffer(nil),
 			exStdout: "a\n",
@@ -57,36 +58,8 @@ func TestSetError(t *testing.T) {
 			exExit:   1,
 			f: func(re ResponseEmitter, t *testing.T) {
 				re.Emit("a")
-				re.SetError("some error", cmdkit.ErrFatal)
+				re.CloseWithError(fmt.Errorf("some error"))
 				re.Emit("b")
-			},
-		},
-
-		tcSetError{
-			stdout:   bytes.NewBuffer(nil),
-			stderr:   bytes.NewBuffer(nil),
-			exStdout: "a\nb\n",
-			exStderr: "Error: some error\n",
-			exExit:   1,
-			f: func(re ResponseEmitter, t *testing.T) {
-				defer re.Close()
-				re.Emit("a")
-				re.SetError("some error", cmdkit.ErrNormal)
-				re.Emit("b")
-			},
-		},
-
-		tcSetError{
-			stdout:   bytes.NewBuffer(nil),
-			stderr:   bytes.NewBuffer(nil),
-			exStdout: "a\nb\n",
-			exStderr: "Error: some error\n",
-			exExit:   3,
-			f: func(re ResponseEmitter, t *testing.T) {
-				re.Emit("a")
-				re.SetError("some error", cmdkit.ErrNormal)
-				re.Emit("b")
-				re.Exit(3)
 			},
 		},
 	}

--- a/command.go
+++ b/command.go
@@ -68,24 +68,40 @@ var ErrIncorrectType = errors.New("The command returned a value with a different
 
 // Call invokes the command for the given Request
 func (c *Command) Call(req *Request, re ResponseEmitter, env Environment) {
-	// we need the named return parameter so we can change the value from defer()
-	defer re.Close()
+	var err error
+
+	defer func() {
+		var closeErr error
+		if err == nil {
+			closeErr = re.Close()
+		} else {
+			if _, ok := err.(cmdkit.Error); !ok {
+				err = cmdkit.Error{Message: err.Error(), Code: cmdkit.ErrFatal}
+			}
+
+			closeErr = re.CloseWithError(err)
+		}
+
+		if closeErr != nil {
+			log.Errorf("error closing connection: %s", closeErr)
+			if err != nil {
+				log.Errorf("close caused by error: %s", err)
+			}
+		}
+	}()
 
 	var cmd *Command
-	cmd, err := c.Get(req.Path)
+	cmd, err = c.Get(req.Path)
 	if err != nil {
-		re.SetError(err, cmdkit.ErrFatal)
 		return
 	}
 
 	if cmd.Run == nil {
-		re.SetError(ErrNotCallable, cmdkit.ErrFatal)
 		return
 	}
 
 	err = cmd.CheckArguments(req)
 	if err != nil {
-		re.SetError(err, cmdkit.ErrFatal)
 		return
 	}
 
@@ -118,6 +134,7 @@ func (c *Command) Call(req *Request, re ResponseEmitter, env Environment) {
 
 			return
 		}
+
 		re.SetError(err, cmdkit.ErrNormal)
 	}
 }

--- a/command.go
+++ b/command.go
@@ -135,7 +135,11 @@ func (c *Command) Call(req *Request, re ResponseEmitter, env Environment) {
 			return
 		}
 
-		re.SetError(err, cmdkit.ErrNormal)
+		cmderr := err
+		err = re.CloseWithError(err)
+		if err != nil {
+			log.Error("error %q closing emitter %q on request %#v", err, cmderr, req)
+		}
 	}
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -22,8 +22,9 @@ func (s *testEmitter) Close() error {
 }
 
 func (s *testEmitter) SetLength(_ uint64) {}
-func (s *testEmitter) SetError(err interface{}, code cmdkit.ErrorType) {
+func (s *testEmitter) CloseWithError(err error) error {
 	(*testing.T)(s).Error(err)
+	return nil
 }
 func (s *testEmitter) Emit(value interface{}) error {
 	return nil
@@ -411,8 +412,9 @@ func (s *testEmitterWithError) Close() error {
 
 func (s *testEmitterWithError) SetLength(_ uint64) {}
 
-func (s *testEmitterWithError) SetError(err interface{}, code cmdkit.ErrorType) {
+func (s *testEmitterWithError) CloseWithError(err error) error {
 	s.errorCount++
+	return nil
 }
 
 func (s *testEmitterWithError) Emit(value interface{}) error {

--- a/examples/adder/cmd.go
+++ b/examples/adder/cmd.go
@@ -35,16 +35,17 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 
 					sum += num
-					re.Emit(fmt.Sprintf("intermediate result: %d; %d left", sum, len(req.Arguments)-i-1))
+					err = re.Emit(fmt.Sprintf("intermediate result: %d; %d left", sum, len(req.Arguments)-i-1))
+					if err != nil {
+						return err
+					}
 				}
 
-				re.Emit(fmt.Sprintf("total: %d", sum))
-				return nil
+				return re.Emit(fmt.Sprintf("total: %d", sum))
 			},
 		},
 		// a bit more sophisticated
@@ -58,15 +59,18 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 
 					sum += num
-					re.Emit(&AddStatus{
+					err = re.Emit(&AddStatus{
 						Current: sum,
 						Left:    len(req.Arguments) - i - 1,
 					})
+					if err != nil {
+						return err
+					}
+
 					time.Sleep(200 * time.Millisecond)
 				}
 				return nil
@@ -102,15 +106,18 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 
 					sum += num
-					re.Emit(&AddStatus{
+					err = re.Emit(&AddStatus{
 						Current: sum,
 						Left:    len(req.Arguments) - i - 1,
 					})
+					if err != nil {
+						return err
+					}
+
 					time.Sleep(200 * time.Millisecond)
 				}
 				return nil
@@ -160,15 +167,18 @@ var RootCmd = &cmds.Command{
 				for i, str := range req.Arguments {
 					num, err := strconv.Atoi(str)
 					if err != nil {
-						re.SetError(err, cmdkit.ErrNormal)
 						return err
 					}
 
 					sum += num
-					re.Emit(&AddStatus{
+					err = re.Emit(&AddStatus{
 						Current: sum,
 						Left:    len(req.Arguments) - i - 1,
 					})
+					if err != nil {
+						return err
+					}
+
 					time.Sleep(200 * time.Millisecond)
 				}
 				return nil

--- a/examples/adder/remote/client/main.go
+++ b/examples/adder/remote/client/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ipfs/go-ipfs-cmds/examples/adder"
 
-	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	//cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	cli "github.com/ipfs/go-ipfs-cmds/cli"
 	http "github.com/ipfs/go-ipfs-cmds/http"
@@ -44,7 +44,7 @@ func main() {
 			err = cmds.Copy(re, res)
 		}
 		if err != nil {
-			re.SetError(err, cmdkit.ErrNormal|cmdkit.ErrFatal)
+			re.CloseWithError(err)
 		}
 		close(wait)
 	}()

--- a/executor.go
+++ b/executor.go
@@ -122,8 +122,5 @@ func (x *executor) Execute(req *Request, re ResponseEmitter, env Environment) (e
 
 	}()
 	err = cmd.Run(req, re, env)
-	if err != nil {
-		re.SetError(err, cmdkit.ErrNormal)
-	}
-	return nil
+	return re.CloseWithError(err)
 }

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -69,17 +69,17 @@ var (
 				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 					version, ok := getVersion(env)
 					if !ok {
-						re.SetError("couldn't get version", cmdkit.ErrNormal)
+						return cmdkit.Errorf(cmdkit.ErrNormal, "couldn't get version")
 					}
 
 					repoVersion, ok := getRepoVersion(env)
 					if !ok {
-						re.SetError("couldn't get repo version", cmdkit.ErrNormal)
+						return cmdkit.Errorf(cmdkit.ErrNormal, "couldn't get repo version")
 					}
 
 					commit, ok := getCommit(env)
 					if !ok {
-						re.SetError("couldn't get commit info", cmdkit.ErrNormal)
+						return cmdkit.Errorf(cmdkit.ErrNormal, "couldn't get commit info")
 					}
 
 					re.Emit(&VersionOutput{

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
       "version": "1.2.7"
     },
     {
-      "hash": "QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM",
+      "hash": "QmVViZcg6N29WMrbfbzuYXFAGVoCvcR5oqadxfnMcLMnmx",
       "name": "go-ipfs-cmdkit",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "author": "whyrusleeping",

--- a/response.go
+++ b/response.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"fmt"
 	"io"
+	"runtime/debug"
 
 	"github.com/ipfs/go-ipfs-cmdkit"
 )
@@ -51,10 +52,9 @@ func HandleError(err error, res Response, re ResponseEmitter) bool {
 			err = res.Error()
 		}
 
-		if e, ok := err.(*cmdkit.Error); ok {
-			re.SetError(e.Message, e.Code)
-		} else {
-			re.SetError(err, cmdkit.ErrNormal)
+		closeErr := re.CloseWithError(err)
+		if err != nil {
+			log.Errorf("error closing with error: %v at %s when closing with error %v", closeErr, debug.Stack(), err)
 		}
 		return false
 	}

--- a/responseemitter.go
+++ b/responseemitter.go
@@ -3,8 +3,7 @@ package cmds
 import (
 	"fmt"
 	"io"
-
-	"github.com/ipfs/go-ipfs-cmdkit"
+	//"github.com/ipfs/go-ipfs-cmdkit"
 )
 
 // Single can be used to signal to any ResponseEmitter that only one value will be emitted.
@@ -29,20 +28,20 @@ func EmitOnce(re ResponseEmitter, v interface{}) error {
 // ResponseEmitter encodes and sends the command code's output to the client.
 // It is all a command can write to.
 type ResponseEmitter interface {
-	// closes http conn or channel
-	io.Closer
+	// Close closes the underlying transport.
+	Close() error
+
+	// CloseWithError closes the underlying transport and makes subsequent read
+	// calls return the passed error.
+	CloseWithError(error) error
 
 	// SetLength sets the length of the output
 	// err is an interface{} so we don't have to manually convert to error.
 	SetLength(length uint64)
 
-	// SetError sets the response error
-	// err is an interface{} so we don't have to manually convert to error.
-	SetError(err interface{}, code cmdkit.ErrorType)
-
-	// Emit sends a value
-	// if value is io.Reader we just copy that to the connection
-	// other values are marshalled
+	// Emit sends a value.
+	// If value is io.Reader we just copy that to the connection
+	// other values are marshalled.
 	Emit(value interface{}) error
 }
 

--- a/responseemitter_test.go
+++ b/responseemitter_test.go
@@ -65,22 +65,12 @@ func TestError(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = re.Emit(cmdkit.Error{Message: "foo"})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = re.Emit(&cmdkit.Error{Message: "bar"})
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		err = re.Emit("value2")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = re.Close()
+		err = re.CloseWithError(&cmdkit.Error{Message: "foo"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -95,19 +85,29 @@ func TestError(t *testing.T) {
 	}
 
 	v, err = res.Next()
-	if err == nil {
-		t.Errorf("expected error, got %#v", v)
-	}
-	v, err = res.Next()
-	if err == nil {
-		t.Errorf("expected error, got %#v", v)
-	}
-
-	v, err = res.Next()
 	if err != nil {
 		t.Error(err)
 	}
 	if v.(string) != "value2" {
 		t.Errorf("expected string %#v but got %#v", "value1", v)
+	}
+
+	v, err = res.Next()
+	if v != nil {
+		t.Errorf("expected nil value, got %#v", v)
+
+	}
+	e, ok := err.(*cmdkit.Error)
+	if !ok {
+		t.Errorf("expected error to be %T, got %T", e, v)
+	} else {
+		expMsg := "foo"
+		if e.Message != expMsg {
+			t.Errorf("expected error message to be %q, got %q", expMsg, e.Message)
+		}
+
+		if e.Code != 0 {
+			t.Errorf("expected error code 0(ErrNormal), got %v", e.Code)
+		}
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -121,6 +121,19 @@ func (re *WriterResponseEmitter) SetEncoder(mkEnc func(io.Writer) Encoder) {
 	re.enc = mkEnc(re.w)
 }
 
+func (re *WriterResponseEmitter) CloseWithError(err error) error {
+	if err == nil {
+		return re.Close()
+	}
+
+	_, ok := err.(*cmdkit.Error)
+	if ok {
+		return re.Emit(err)
+	}
+
+	return re.Emit(&cmdkit.Error{Message: err.Error(), Code: cmdkit.ErrNormal})
+}
+
 func (re *WriterResponseEmitter) SetError(v interface{}, errType cmdkit.ErrorType) {
 	err := re.Emit(&cmdkit.Error{Message: fmt.Sprint(v), Code: errType})
 	if err != nil {


### PR DESCRIPTION
This change set drops the `SetError` method on `ResponseEmitter` but introduces `CloseWithError`, as suggested in #98.

It sits on top of the branches of PR #97 and #102 to avoid a huge pile of rebasing later, so let's wait with merging until those are in. The `tmp/prebundle` branch has the changes of these PRs, so we can review the changes of this PR individually.

This needs to be squashed before merging, I'll do that when the review is through.