### PR TITLE
set the connection close header if we have a body to read

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -157,6 +157,13 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// If we have a request body, close the connection when we're done.
+	// FIXME: https://github.com/ipfs/go-ipfs/issues/5168
+	// FIXME: https://github.com/golang/go/issues/15527
+	if r.Body != http.NoBody {
+		w.Header().Set("Connection", "close")
+	}
+
 	re := NewResponseEmitter(w, r.Method, req)
 	h.root.Call(req, re, h.env)
 }


### PR DESCRIPTION
We can't stream a response while reading a body *unless* we've configured the
connection to close after we're done sending a response.

This patch works around that issue by doing exactly that.