### PR TITLE
fix(option): print error message for error timeout option

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -39,6 +39,7 @@ func Run(ctx context.Context, root *cmds.Command,
 	if timeoutStr, ok := req.Options[cmds.TimeoutOpt]; ok {
 		timeout, err := time.ParseDuration(timeoutStr.(string))
 		if err != nil {
+			printErr(err)
 			return err
 		}
 		req.Context, cancel = context.WithTimeout(req.Context, timeout)


### PR DESCRIPTION
License: MIT
Signed-off-by: Overbool <overbool.xu@gmail.com>

Fixes: https://github.com/ipfs/go-ipfs-cmds/issues/117
Fixes in ipfs: ipfs/go-ipfs#4964