### PR TITLE
fix encoding/decoding again

### DIFF
--- a/cli/responseemitter.go
+++ b/cli/responseemitter.go
@@ -14,25 +14,21 @@ import (
 
 var _ ResponseEmitter = &responseEmitter{}
 
-func NewResponseEmitter(stdout, stderr io.Writer, enc func(*cmds.Request) func(io.Writer) cmds.Encoder, req *cmds.Request) (cmds.ResponseEmitter, <-chan int) {
+func NewResponseEmitter(stdout, stderr io.Writer, req *cmds.Request) (cmds.ResponseEmitter, <-chan int, error) {
 	ch := make(chan int)
-	encType := cmds.GetEncoding(req)
-
-	if enc == nil {
-		enc = func(*cmds.Request) func(io.Writer) cmds.Encoder {
-			return func(io.Writer) cmds.Encoder {
-				return nil
-			}
-		}
+	encType, enc, err := cmds.GetEncoder(req, stdout, cmds.TextNewline)
+	if err != nil {
+		close(ch)
+		return nil, ch, err
 	}
 
 	return &responseEmitter{
 		stdout:  stdout,
 		stderr:  stderr,
 		encType: encType,
-		enc:     enc(req)(stdout),
+		enc:     enc,
 		ch:      ch,
-	}, ch
+	}, ch, err
 }
 
 // ResponseEmitter extends cmds.ResponseEmitter to give better control over the command line

--- a/cli/responseemitter_test.go
+++ b/cli/responseemitter_test.go
@@ -23,8 +23,10 @@ type tcCloseWithError struct {
 
 func (tc tcCloseWithError) Run(t *testing.T) {
 	req := &cmds.Request{}
-
-	cmdsre, exitCh := NewResponseEmitter(tc.stdout, tc.stderr, nil, req)
+	cmdsre, exitCh, err := NewResponseEmitter(tc.stdout, tc.stderr, req)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	re := cmdsre.(ResponseEmitter)
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -134,12 +134,10 @@ func Run(ctx context.Context, root *cmds.Command,
 	}
 
 	// first if condition checks the command's encoder map, second checks global encoder map (cmd vs. cmds)
-	if enc, ok := cmd.Encoders[encType]; ok {
-		re, exitCh = NewResponseEmitter(stdout, stderr, enc, req)
-	} else if enc, ok := cmds.Encoders[encType]; ok {
-		re, exitCh = NewResponseEmitter(stdout, stderr, enc, req)
-	} else {
-		return fmt.Errorf("could not find matching encoder for enctype %#v", encType)
+	re, exitCh, err = NewResponseEmitter(stdout, stderr, req)
+	if err != nil {
+		printErr(err)
+		return err
 	}
 
 	errCh := make(chan error, 1)

--- a/cli/single_test.go
+++ b/cli/single_test.go
@@ -16,7 +16,10 @@ func TestSingle(t *testing.T) {
 
 	var bufout, buferr bytes.Buffer
 
-	re, exitCh := NewResponseEmitter(&bufout, &buferr, cmds.Encoders["cli"], req)
+	re, exitCh, err := NewResponseEmitter(&bufout, &buferr, req)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wait := make(chan struct{})
 

--- a/examples/adder/local/main.go
+++ b/examples/adder/local/main.go
@@ -21,7 +21,10 @@ func main() {
 	req.Options["encoding"] = cmds.Text
 
 	// create an emitter
-	re, retCh := cli.NewResponseEmitter(os.Stdout, os.Stderr, req.Command.Encoders["Text"], req)
+	re, retCh, err := cli.NewResponseEmitter(os.Stdout, os.Stderr, req)
+	if err != nil {
+		panic(err)
+	}
 
 	if pr, ok := req.Command.PostRun[cmds.CLI]; ok {
 		var (

--- a/examples/adder/remote/client/main.go
+++ b/examples/adder/remote/client/main.go
@@ -31,7 +31,10 @@ func main() {
 	req.Options["encoding"] = cmds.Text
 
 	// create an emitter
-	re, retCh := cli.NewResponseEmitter(os.Stdout, os.Stderr, req.Command.Encoders["Text"], req)
+	re, retCh, err := cli.NewResponseEmitter(os.Stdout, os.Stderr, req)
+	if err != nil {
+		panic(err)
+	}
 
 	wait := make(chan struct{})
 	// copy received result into cli emitter

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -68,6 +68,35 @@ func TestErrors(t *testing.T) {
 		},
 
 		{
+			path: []string{"protoencode"},
+			opts: cmdkit.OptMap{
+				cmds.EncLong: cmds.Protobuf,
+			},
+			status:  "500 Internal Server Error",
+			bodyStr: `{"Message":"an error occurred","Code":0,"Type":"error"}` + "\n",
+		},
+
+		{
+			path: []string{"protolateencode"},
+			opts: cmdkit.OptMap{
+				cmds.EncLong: cmds.Protobuf,
+			},
+			status:     "200 OK",
+			bodyStr:    "hello\n",
+			errTrailer: "an error occurred",
+		},
+
+		{
+			// bad encoding
+			path: []string{"error"},
+			opts: cmdkit.OptMap{
+				cmds.EncLong: "foobar",
+			},
+			status:  "400 Bad Request",
+			bodyStr: `invalid encoding: foobar`,
+		},
+
+		{
 			path:    []string{"doubleclose"},
 			status:  "200 OK",
 			bodyStr: `"some value"` + "\n",

--- a/http/handler.go
+++ b/http/handler.go
@@ -145,6 +145,13 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
+	re, err := NewResponseEmitter(w, r.Method, req)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
 	if reqLogger, ok := h.env.(requestLogger); ok {
 		done := reqLogger.LogRequest(req)
 		defer done()
@@ -157,12 +164,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	re, err := NewResponseEmitter(w, r.Method, req)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error()))
-		return
-	}
 	h.root.Call(req, re, h.env)
 }
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -159,7 +159,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	re, err := NewResponseEmitter(w, r.Method, req)
 	if err != nil {
-		re.CloseWithError(err)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
 		return
 	}
 	h.root.Call(req, re, h.env)

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -110,6 +110,31 @@ var (
 					}),
 				},
 			},
+			"protoencode": &cmds.Command{
+				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+					return errors.New("an error occurred")
+				},
+				Type: "",
+				Encoders: cmds.EncoderMap{
+					cmds.Protobuf: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, v string) error {
+						fmt.Fprintln(w, v)
+						return nil
+					}),
+				},
+			},
+			"protolateencode": &cmds.Command{
+				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+					re.Emit("hello")
+					return errors.New("an error occurred")
+				},
+				Type: "",
+				Encoders: cmds.EncoderMap{
+					cmds.Protobuf: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, v string) error {
+						fmt.Fprintln(w, v)
+						return nil
+					}),
+				},
+			},
 			"doubleclose": &cmds.Command{
 				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 					t, ok := getTestingT(env)

--- a/request.go
+++ b/request.go
@@ -139,19 +139,17 @@ func (req *Request) convertOptions(root *Command) error {
 }
 
 // GetEncoding returns the EncodingType set in a request, falling back to JSON
-func GetEncoding(req *Request) EncodingType {
-	encIface := req.Options[EncLong]
-	if encIface == nil {
-		return JSON
-	}
-
-	switch enc := encIface.(type) {
+func GetEncoding(req *Request, def EncodingType) EncodingType {
+	switch enc := req.Options[EncLong].(type) {
 	case string:
 		return EncodingType(enc)
 	case EncodingType:
 		return enc
 	default:
-		return JSON
+		if def == "" {
+			return DefaultOutputEncoding
+		}
+		return def
 	}
 }
 


### PR DESCRIPTION
This time, we completely separate error encoding and let the emitter deal with it. Basically:

1. Some transports won't even use the same channel.
2. We don't *have* an error "encoder" for protobuf.

We now *finally* return the correct content type (json) when returning an error after passing `--enc=protobuf`.

This *also*:

1. Removes GetDecoder. We need to special case this every time anyways.
2. Allows transports to specify the "default" encoding type instead of assuming JSON.
3. Ensure that we never mistake a value for an error in the HTTP transport by converting to a cmdkit.Error *before* passing errors to `doPreamble`.

Finally, this fixes a panic where we were trying to use a response emitter that we failed to construct.