### PR TITLE
Fix dot path parsing on Windows

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -466,7 +466,7 @@ func appendFile(fpath string, argDef *cmdkit.Argument, recursive, hidden bool) (
 		if err != nil {
 			return nil, err
 		}
-		fpath = cwd
+		fpath = filepath.ToSlash(cwd)
 	}
 
 	stat, err := os.Lstat(fpath)


### PR DESCRIPTION
Originally fixed in: https://github.com/ipfs/go-ipfs/pull/2614
reverted in https://github.com/ipfs/go-ipfs-cmds/pull/121

Filepath was taking our IPFS friendly paths and returning system local paths.
Above is pre-patch, below is post patch
![dot fix 2 0](https://user-images.githubusercontent.com/13862850/47581176-b7298d00-d91e-11e8-819c-f3f226fd8c19.png)

