### PR TITLE
MakeTypedEncoder: accept results by pointer or value

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -92,16 +92,23 @@ func MakeTypedEncoder(f interface{}) func(*Request) func(io.Writer) Encoder {
 	}
 
 	valType := t.In(2)
+	valTypePtr := reflect.PtrTo(valType)
 
 	return MakeEncoder(func(req *Request, w io.Writer, i interface{}) error {
-		if reflect.TypeOf(i) != valType {
+		iType := reflect.TypeOf(i)
+		iValue := reflect.ValueOf(i)
+		switch iType {
+		case valType:
+		case valTypePtr:
+			iValue = iValue.Elem()
+		default:
 			return fmt.Errorf("unexpected type %T, expected %v", i, valType)
 		}
 
 		out := val.Call([]reflect.Value{
 			reflect.ValueOf(req),
 			reflect.ValueOf(w),
-			reflect.ValueOf(i),
+			iValue,
 		})
 
 		err, ok := out[0].Interface().(error)

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -36,6 +36,31 @@ func TestMakeTypedEncoder(t *testing.T) {
 	}
 }
 
+func TestMakeTypedEncoderByValue(t *testing.T) {
+	expErr := fmt.Errorf("command fooTestObj failed")
+	f := MakeTypedEncoder(func(req *Request, w io.Writer, v fooTestObj) error {
+		if v.Good {
+			return nil
+		}
+		return expErr
+	})
+
+	req := &Request{}
+
+	encoderFunc := f(req)
+
+	buf := new(bytes.Buffer)
+	encoder := encoderFunc(buf)
+
+	if err := encoder.Encode(&fooTestObj{true}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := encoder.Encode(&fooTestObj{false}); err != expErr {
+		t.Fatal("expected: ", expErr)
+	}
+}
+
 func TestMakeTypedEncoderArrays(t *testing.T) {
 	f := MakeTypedEncoder(func(req *Request, w io.Writer, v []fooTestObj) error {
 		if len(v) != 2 {


### PR DESCRIPTION
Internally, we always deserialize using pointers. However, we sometimes want to deal with values *by value* instead. This makes `MakeTypedEncoder` handle both cases.