### PR TITLE
add strings option support

### DIFF
--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -34,7 +34,14 @@ func sameKVs(a kvs, b kvs) bool {
 		return false
 	}
 	for k, v := range a {
-		if v != b[k] {
+		if ks, ok := v.([]string); ok {
+			bks, _ := b[k].([]string)
+			for i := 0; i < len(ks); i++ {
+				if ks[i] != bks[i] {
+					return false
+				}
+			}
+		} else if v != b[k] {
 			return false
 		}
 	}
@@ -73,6 +80,7 @@ func TestOptionParsing(t *testing.T) {
 		Options: []cmdkit.Option{
 			cmdkit.StringOption("string", "s", "a string"),
 			cmdkit.BoolOption("bool", "b", "a bool"),
+			cmdkit.StringsOption("strings", "r", "strings array"),
 		},
 		Subcommands: map[string]*cmds.Command{
 			"test": &cmds.Command{},
@@ -142,6 +150,7 @@ func TestOptionParsing(t *testing.T) {
 	test("-b test false", kvs{"bool": true}, words{"false"})
 	test("-b --string foo test bar", kvs{"bool": true, "string": "foo"}, words{"bar"})
 	test("-b=false --string bar", kvs{"bool": false, "string": "bar"}, words{})
+	test("--strings a --strings b", kvs{"strings": []string{"a", "b"}}, words{})
 	testFail("foo test")
 	test("defaults", kvs{"opt": "def"}, words{})
 	test("defaults -o foo", kvs{"opt": "foo"}, words{})

--- a/request.go
+++ b/request.go
@@ -108,7 +108,7 @@ func (req *Request) convertOptions(root *Command) error {
 		}
 
 		kind := reflect.TypeOf(v).Kind()
-		if kind != opt.Type() {
+		if kind != opt.Type() && opt.Type() != cmdkit.Strings {
 			if str, ok := v.(string); ok {
 				val, err := opt.Parse(str)
 				if err != nil {


### PR DESCRIPTION
Command strings array option. Fix issue [ipfs/go-ipfs-cmdkit#5](https://github.com/ipfs/go-ipfs-cmdkit/issues/5)

It works like that:

$ ipfs --strings .git --strings yarn.lock -r .

the reason why i do this is for [ipfs/go-ipfs#3643](https://github.com/ipfs/go-ipfs/issues/3643)

Note: It should should merge after [ipfs/go-ipfs-cmdkit#32](https://github.com/ipfs/go-ipfs-cmdkit/pull/32).
The test will be passed after  [ipfs/go-ipfs-cmdkit#32](https://github.com/ipfs/go-ipfs-cmdkit/pull/32) being merged