### PR TITLE
Don't skip stdin test on Windows

### DIFF
--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -6,12 +6,11 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
-	"github.com/ipfs/go-ipfs-cmdkit"
-	"github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 )
 
 type kvs map[string]interface{}
@@ -154,10 +153,6 @@ func TestOptionParsing(t *testing.T) {
 }
 
 func TestArgumentParsing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("stdin handling doesn't yet work on windows")
-	}
-
 	rootCmd := &cmds.Command{
 		Subcommands: map[string]*cmds.Command{
 			"noarg": {},


### PR DESCRIPTION
Issues around this were resolved, but the test was never "un-skipped".
```
C:\...\ipfs\go-ipfs-cmds\cli>systeminfo | findstr /B /C:"OS Version"
OS Version:                10.0.17763 N/A Build 17763

C:\...\ipfs\go-ipfs-cmds\cli>go test -v
=== RUN   TestSynopsisGenerator
--- PASS: TestSynopsisGenerator (0.00s)
    helptext_test.go:27: Synopsis is: cmd [--opt=<OPTION> | -o] [--] <required> [<variadic>...]
=== RUN   TestSameWords
--- PASS: TestSameWords (0.00s)
=== RUN   TestOptionParsing
--- PASS: TestOptionParsing (0.00s)
=== RUN   TestArgumentParsing
--- PASS: TestArgumentParsing (0.00s)
=== RUN   TestBodyArgs
--- PASS: TestBodyArgs (0.00s)
=== RUN   TestCloseWithError
--- PASS: TestCloseWithError (0.00s)
    responseemitter_test.go:88: 0
    responseemitter_test.go:47: stdout:
        ---
        a
        ---
    responseemitter_test.go:48: stderr:
        ---
        Error: some error
        ---
    responseemitter_test.go:88: 1
    responseemitter_test.go:47: stdout:
        ---
        a
        ---
    responseemitter_test.go:48: stderr:
        ---
        Error: some error
        ---
=== RUN   TestSingle
--- PASS: TestSingle (0.00s)
PASS
ok      github.com/ipfs/go-ipfs-cmds/cli        0.048s
```