### PR TITLE
gx publish 2.0.10 - Update cors library

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-2.0.9: QmaAP56JAwdjwisPTu4yx17whcjTr6y5JCSCF77Y1rahWV
+2.0.10: QmWGm4AbZEbnmdgVTza52MSNpEmBdFVqzmAysRbjrRyGbH

--- a/http/reforigin_test.go
+++ b/http/reforigin_test.go
@@ -171,7 +171,7 @@ func TestWildcardOrigin(t *testing.T) {
 			Origin:       origin,
 			AllowOrigins: allowedOrigins,
 			ResHeaders: map[string]string{
-				ACAOrigin:                       origin,
+				ACAOrigin:                       "*",
 				ACAMethods:                      "",
 				ACACredentials:                  "",
 				"Access-Control-Max-Age":        "",
@@ -259,7 +259,7 @@ func TestWildcardReferer(t *testing.T) {
 			Origin:       origin,
 			AllowOrigins: allowedOrigins,
 			ResHeaders: map[string]string{
-				ACAOrigin:                       origin,
+				ACAOrigin:                       "*",
 				ACAMethods:                      "",
 				ACACredentials:                  "",
 				"Access-Control-Max-Age":        "",
@@ -289,7 +289,7 @@ func TestAllowedMethod(t *testing.T) {
 	gtc := func(method string, ok bool) httpTestCase {
 		code := http.StatusOK
 		hdrs := map[string]string{
-			ACAOrigin:                       "http://localhost",
+			ACAOrigin:                       "*",
 			ACAMethods:                      method,
 			ACACredentials:                  "",
 			"Access-Control-Max-Age":        "",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     },
     {
       "author": "rs",
-      "hash": "QmPG2kW5t27LuHgHnvhUwbHCNHAt2eUcb4gPHqofrESUdB",
+      "hash": "QmNNk4iczWp8Q4R1mXQ2mrrjQvWisYqMqbW1an8qGbJZsM",
       "name": "cors",
-      "version": "0.0.0"
+      "version": "1.6.0"
     },
     {
       "author": "whyrusleeping",
@@ -53,6 +53,6 @@
   "license": "MIT",
   "name": "go-ipfs-cmds",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "2.0.9"
+  "version": "2.0.10"
 }
 


### PR DESCRIPTION
I have put an updated version of `cors` in the `gxed` organization. This updates it.