### PR TITLE
cli: fix ignoring std{out,err} sync errors on windows

### DIFF
--- a/cli/error.go
+++ b/cli/error.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"os"
+)
+
+func isSyncNotSupportedErr(err error) bool {
+	perr, ok := err.(*os.PathError)
+	if !ok {
+		return false
+	}
+	return perr.Op == "sync" && isErrnoNotSupported(perr.Err)
+}

--- a/cli/error_posix.go
+++ b/cli/error_posix.go
@@ -1,0 +1,15 @@
+//+build !windows
+
+package cli
+
+import (
+	"syscall"
+)
+
+func isErrnoNotSupported(err error) bool {
+	switch err {
+	case syscall.EINVAL, syscall.ENOTSUP:
+		return true
+	}
+	return false
+}

--- a/cli/error_windows.go
+++ b/cli/error_windows.go
@@ -1,0 +1,17 @@
+//+build windows
+
+package cli
+
+import (
+	"syscall"
+)
+
+const invalid_file_handle syscall.Errno = 0x6
+
+func isErrnoNotSupported(err error) bool {
+	switch err {
+	case syscall.EINVAL, syscall.ENOTSUP, invalid_file_handle:
+		return true
+	}
+	return false
+}

--- a/cli/responseemitter.go
+++ b/cli/responseemitter.go
@@ -12,6 +12,8 @@ import (
 
 var _ ResponseEmitter = &responseEmitter{}
 
+// NewResponseEmitter constructs a new response emitter that writes results to
+// the console.
 func NewResponseEmitter(stdout, stderr io.Writer, req *cmds.Request) (ResponseEmitter, error) {
 	encType, enc, err := cmds.GetEncoder(req, stdout, cmds.TextNewline)
 


### PR DESCRIPTION
fixes ipfs/go-ipfs#6021