### PR TITLE
fix sync error with go1.12 on darwin

### DIFF
--- a/cli/error_posix.go
+++ b/cli/error_posix.go
@@ -8,7 +8,7 @@ import (
 
 func isErrnoNotSupported(err error) bool {
 	switch err {
-	case syscall.EINVAL, syscall.ENOTSUP:
+	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY:
 		return true
 	}
 	return false

--- a/cli/error_windows.go
+++ b/cli/error_windows.go
@@ -10,7 +10,7 @@ const invalid_file_handle syscall.Errno = 0x6
 
 func isErrnoNotSupported(err error) bool {
 	switch err {
-	case syscall.EINVAL, syscall.ENOTSUP, invalid_file_handle:
+	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY, invalid_file_handle:
 		return true
 	}
 	return false


### PR DESCRIPTION
In go1.12, go switched how `file.Sync()` works on macos. Unfortunately, this also changed the "not supported" error to ENOTTY (called ENOTTY for legacy reasons) on macos.

fixes ipfs/go-ipfs#6028