### PR TITLE
don't return copied errors from Copy

### DIFF
--- a/responseemitter.go
+++ b/responseemitter.go
@@ -61,12 +61,7 @@ func Copy(re ResponseEmitter, res Response) error {
 				return re.Close()
 			}
 
-			closeErr := re.CloseWithError(err)
-			if closeErr != nil {
-				log.Errorf("error closing emitter with error %q: %s", err, closeErr)
-			}
-
-			return err
+			return re.CloseWithError(err)
 		}
 
 		err = re.Emit(v)

--- a/responseemitter_test.go
+++ b/responseemitter_test.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 
@@ -48,6 +49,51 @@ func TestCopy(t *testing.T) {
 	_, err = res2.Next()
 	if err != io.EOF {
 		t.Fatalf("expected EOF but got err=%v", err)
+	}
+}
+
+func TestCopyError(t *testing.T) {
+	req, err := NewRequest(context.Background(), nil, nil, nil, nil, &Command{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fooErr := fmt.Errorf("foo")
+
+	re1, res1 := NewChanResponsePair(req)
+	re2, res2 := NewChanResponsePair(req)
+
+	go func() {
+		err := Copy(re2, res1)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	go func() {
+		err := re1.Emit("test")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = re1.CloseWithError(fooErr)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	v, err := res2.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	str := v.(string)
+	if str != "test" {
+		t.Fatalf("expected string %#v but got %#v", "test", str)
+	}
+
+	_, err = res2.Next()
+	if err != fooErr {
+		t.Fatalf("expected fooErr but got err=%v", err)
 	}
 }
 


### PR DESCRIPTION
We _copy_ the error to the response, we only need to return errors encountered when copying.

fixes #148