### PR TITLE
cli: also ignore EBADF when syncing

### DIFF
--- a/cli/error_posix.go
+++ b/cli/error_posix.go
@@ -8,7 +8,17 @@ import (
 
 func isErrnoNotSupported(err error) bool {
 	switch err {
-	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY:
+	case
+		// Operation not supported
+		syscall.EINVAL, syscall.EROFS, syscall.ENOTSUP,
+		// File descriptor doesn't support syncing (found on MacOS).
+		syscall.ENOTTY,
+		// MacOS is weird. It returns EBADF when calling fsync on stdout
+		// when piped.
+		//
+		// This is never returned for, e.g., filesystem errors so
+		// there's nothing we can do but ignore it and continue.
+		syscall.EBADF:
 		return true
 	}
 	return false


### PR DESCRIPTION
MacOS returns this when syncing stdout when piped.