### PR TITLE
cli: don't sync output to NUL on Windows

### DIFF
--- a/cli/error_windows.go
+++ b/cli/error_windows.go
@@ -6,11 +6,14 @@ import (
 	"syscall"
 )
 
-const invalid_file_handle syscall.Errno = 0x6
+const (
+	invalid_file_handle     syscall.Errno = 0x6 // console output is not buffered on this platform
+	invalid_handle_function syscall.Errno = 0x1 // this is specifically returned when NUL is the FlushFileBuffers target
+)
 
 func isErrnoNotSupported(err error) bool {
 	switch err {
-	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY, invalid_file_handle:
+	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY, invalid_file_handle, invalid_handle_function:
 		return true
 	}
 	return false


### PR DESCRIPTION
I know the documentation seems backwards, but it's not.
fixes ipfs/go-ipfs#6039
followup to https://github.com/ipfs/go-ipfs-cmds/pull/146