### PR TITLE
support url paths as files.WebFile

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -269,6 +270,8 @@ func parseArgs(req *cmds.Request, root *cmds.Command, stdin *os.File) error {
 					if err != nil {
 						return err
 					}
+				} else if u := isURL(fpath); u != nil {
+					file = files.NewWebFile(u)
 				} else {
 					fpath = filepath.ToSlash(filepath.Clean(fpath))
 					derefArgs, _ := req.Options[cmds.DerefLong].(bool)
@@ -336,6 +339,23 @@ func parseArgs(req *cmds.Request, root *cmds.Command, stdin *os.File) error {
 	}
 
 	return nil
+}
+
+// isURL returns a url.URL for valid http:// and https:// URLs, otherwise it returns nil.
+func isURL(path string) *url.URL {
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil
+	}
+	if u.Host == "" {
+		return nil
+	}
+	switch u.Scheme {
+	default:
+		return nil
+	case "http", "https":
+		return u
+	}
 }
 
 func splitkv(opt string) (k, v string, ok bool) {

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -513,3 +513,24 @@ func TestBodyArgs(t *testing.T) {
 		}
 	}
 }
+
+func Test_isURL(t *testing.T) {
+	for _, u := range []string{
+		"http://www.example.com",
+		"https://www.example.com",
+	} {
+		if isURL(u) == nil {
+			t.Errorf("expected url: %s", u)
+		}
+	}
+
+	for _, u := range []string{
+		"adir/afile",
+		"http:/ /afile",
+		"http:/a/file",
+	} {
+		if isURL(u) != nil {
+			t.Errorf("expected non-url: %s", u)
+		}
+	}
+}


### PR DESCRIPTION
This PR updates the `cli` parser to create `files.WebFile`s for URL paths. ~It also updates the `go-ipfs-files` dependency to `v0.0.2` (to support `nocopy` from https://github.com/ipfs/go-ipfs-files/pull/13). This version is not strictly required to compile or use URLs alone (what really matter is which version `go-ipfs` uses), but simplifies things by coupling `nocopy` support from the start.~

Towards https://github.com/ipfs/go-ipfs/issues/6065
~Draft until `go-ipfs-files` `v0.0.2` is released.~