### PR TITLE
set WebFile fpath to URL base

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -276,6 +276,17 @@ func parseArgs(req *cmds.Request, root *cmds.Command, stdin *os.File) error {
 						return err
 					}
 				} else if u := isURL(fpath); u != nil {
+					base := urlBase(u)
+					fpath = base
+					if _, ok := fileArgs[fpath]; ok {
+						// Ensure a unique fpath by suffixing ' (n)'.
+						for i := 1; ; i++ {
+							fpath = fmt.Sprintf("%s (%d)", base, i)
+							if _, ok := fileArgs[fpath]; !ok {
+								break
+							}
+						}
+					}
 					file = files.NewWebFile(u)
 				} else {
 					fpath = filepath.ToSlash(filepath.Clean(fpath))
@@ -361,6 +372,13 @@ func isURL(path string) *url.URL {
 	case "http", "https":
 		return u
 	}
+}
+
+func urlBase(u *url.URL) string {
+	if u.Path == "" {
+		return u.Host
+	}
+	return path.Base(u.Path)
 }
 
 func splitkv(opt string) (k, v string, ok bool) {

--- a/cli/parse_test.go
+++ b/cli/parse_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -531,6 +532,24 @@ func Test_isURL(t *testing.T) {
 	} {
 		if isURL(u) != nil {
 			t.Errorf("expected non-url: %s", u)
+		}
+	}
+}
+
+func Test_urlBase(t *testing.T) {
+	for _, test := range []struct{ url, base string }{
+		{"http://host", "host"},
+		{"http://host/test", "test"},
+		{"http://host/test?param=val", "test"},
+		{"http://host/test?param=val&param2=val", "test"},
+	} {
+		u, err := url.Parse(test.url)
+		if err != nil {
+			t.Errorf("failed to parse %q: %v", test.url, err)
+			continue
+		}
+		if got := urlBase(u); got != test.base {
+			t.Errorf("expected %q but got %q", test.base, got)
 		}
 	}
 }


### PR DESCRIPTION
This PR sets the `fpath` for `WebFile`s to the 'base' of the URL, which is the base of the *path* if non-empty, otherwise the host.
Follow up from #154 