### PR TITLE
sync: add yet another sync error

### DIFF
--- a/cli/error_posix.go
+++ b/cli/error_posix.go
@@ -12,7 +12,7 @@ func isErrnoNotSupported(err error) bool {
 		// Operation not supported
 		syscall.EINVAL, syscall.EROFS, syscall.ENOTSUP,
 		// File descriptor doesn't support syncing (found on MacOS).
-		syscall.ENOTTY,
+		syscall.ENOTTY, syscall.ENODEV,
 		// MacOS is weird. It returns EBADF when calling fsync on stdout
 		// when piped.
 		//


### PR DESCRIPTION
~So, this one _could_ lead to false negatives, I think, if the hard drive gets disconnected. However, there's not much we can do about that.~ Actually, I think this should be just fine.

fixes https://github.com/ipfs/go-ipfs/issues/6193