### PR TITLE
fix: return the correct error

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -96,7 +96,7 @@ func (c *client) Execute(req *cmds.Request, re cmds.ResponseEmitter, env cmds.En
 				return nil
 			}
 
-			return err
+			return closeErr
 		}
 	}
 


### PR DESCRIPTION
This was causing cancel errors to be printed twice.