### PR TITLE
http: use the request context

### DIFF
--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -28,10 +28,6 @@ type env struct {
 	ch chan struct{}
 }
 
-func (e env) Context() context.Context {
-	return context.Background()
-}
-
 func TestRunWaits(t *testing.T) {
 	flag := make(chan struct{}, 1)
 

--- a/examples/adder/remote/server/main.go
+++ b/examples/adder/remote/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	nethttp "net/http"
 
 	"github.com/ipfs/go-ipfs-cmds/examples/adder"
@@ -10,10 +9,6 @@ import (
 )
 
 type env struct{}
-
-func (env) Context() context.Context {
-	return context.TODO()
-}
 
 func main() {
 	h := http.NewHandler(env{}, adder.RootCmd, http.NewServerConfig())

--- a/executor.go
+++ b/executor.go
@@ -8,12 +8,8 @@ type Executor interface {
 	Execute(req *Request, re ResponseEmitter, env Environment) error
 }
 
-// Environment is the environment passed to commands. The only required method
-// is Context.
-type Environment interface {
-	// Context returns the environment's context.
-	Context() context.Context
-}
+// Environment is the environment passed to commands.
+type Environment interface{}
 
 // MakeEnvironment takes a context and the request to construct the environment
 // that is passed to the command's Run function.

--- a/executor_test.go
+++ b/executor_test.go
@@ -38,10 +38,6 @@ type wc struct {
 
 type env int
 
-func (e *env) Context() context.Context {
-	return context.Background()
-}
-
 func TestExecutor(t *testing.T) {
 	env := env(42)
 	req, err := NewRequest(context.Background(), []string{"test"}, nil, nil, nil, root)

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -26,13 +25,8 @@ type VersionOutput struct {
 
 type testEnv struct {
 	version, commit, repoVersion string
-	rootCtx                      context.Context
 	t                            *testing.T
 	wait                         chan struct{}
-}
-
-func (env testEnv) Context() context.Context {
-	return env.rootCtx
 }
 
 func getCommit(env cmds.Environment) (string, bool) {
@@ -307,7 +301,6 @@ func getTestServer(t *testing.T, origins []string) (cmds.Environment, *httptest.
 		version:     "0.1.2",
 		commit:      "c0mm17", // yes, I know there's no 'm' in hex.
 		repoVersion: "4",
-		rootCtx:     context.Background(),
 		t:           t,
 		wait:        make(chan struct{}),
 	}

--- a/http/parse.go
+++ b/http/parse.go
@@ -1,10 +1,10 @@
 package http
 
 import (
-	"crypto/rand"
 	"encoding/base32"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"mime"
 	"net/http"
 	"strconv"

--- a/http/parse_test.go
+++ b/http/parse_test.go
@@ -33,7 +33,7 @@ func TestParse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := parseRequest(nil, r, root)
+	req, err := parseRequest(r, root)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestParse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err = parseRequest(nil, r, root)
+	req, err = parseRequest(r, root)
 	if err != ErrNotFound {
 		t.Errorf("expected ErrNotFound, got: %v", err)
 	}
@@ -78,7 +78,7 @@ func (tc parseReqTestCase) test(t *testing.T) {
 	}
 	httpReq.URL.RawQuery = vs.Encode()
 
-	req, err := parseRequest(nil, httpReq, cmdRoot)
+	req, err := parseRequest(httpReq, cmdRoot)
 	if !errEq(err, tc.err) {
 		t.Fatalf("expected error to be %v, but got %v", tc.err, err)
 	}


### PR DESCRIPTION
CloseNotifier has been deprecated for a while.

Also, ditch the "environment" context. We don't actually _need_ this.