### PR TITLE
fix: use golang's http.Error to send errors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,0 @@
-# Please see https://help.github.com/articles/about-codeowners/ for more information
-
-# Global owner
-*		@keks
-
-# Subsystem specific owners

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -92,7 +92,7 @@ func TestErrors(t *testing.T) {
 				cmds.EncLong: "foobar",
 			},
 			status:  "400 Bad Request",
-			bodyStr: `invalid encoding: foobar`,
+			bodyStr: "invalid encoding: foobar\n",
 		},
 
 		{

--- a/http/handler.go
+++ b/http/handler.go
@@ -96,8 +96,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if !allowOrigin(r, h.cfg) || !allowReferer(r, h.cfg) {
-		w.WriteHeader(http.StatusForbidden)
-		w.Write([]byte("403 - Forbidden"))
+		http.Error(w, "403 - Forbidden", http.StatusForbidden)
 		log.Warningf("API blocked request to %s. (possible CSRF)", r.URL)
 		return
 	}
@@ -122,12 +121,12 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	req, err := parseRequest(r, h.root)
 	if err != nil {
+		status := http.StatusBadRequest
 		if err == ErrNotFound {
-			w.WriteHeader(http.StatusNotFound)
-		} else {
-			w.WriteHeader(http.StatusBadRequest)
+			status = http.StatusNotFound
 		}
-		w.Write([]byte(err.Error()))
+
+		http.Error(w, err.Error(), status)
 		return
 	}
 
@@ -146,8 +145,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	re, err := NewResponseEmitter(w, r.Method, req, withRequestBodyEOFChan(bodyEOFChan))
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error()))
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
This:

1. Ensures the correct content type.
2. Tells browsers not to sniff the content type.

This prevents any nasties from happening...