### PR TITLE
feat: improve error codes

### DIFF
--- a/error.go
+++ b/error.go
@@ -11,12 +11,17 @@ type ErrorType uint
 
 // ErrorTypes convey what category of error ocurred
 const (
-	ErrNormal         ErrorType = iota // general errors
-	ErrClient                          // error was caused by the client, (e.g. invalid CLI usage)
-	ErrImplementation                  // programmer error in the server
-	ErrNotFound                        // == HTTP 404
-	ErrFatal                           // abort instantly
-	// TODO: add more types of errors for better error-specific handling
+	// ErrNormal is a normal error. The command failed for some reason that's not a bug.
+	ErrNormal ErrorType = iota
+	// ErrClient means the client made an invalid request.
+	ErrClient
+	// ErrImplementation means there's a bug in the implementation.
+	ErrImplementation
+	// ErrRateLimited is returned when the operation has been rate-limited.
+	ErrRateLimited
+	// ErrForbidden is returned when the client doesn't have permission to
+	// perform the requested operation.
+	ErrForbidden
 )
 
 // Error is a struct for marshalling errors

--- a/http/parse.go
+++ b/http/parse.go
@@ -216,7 +216,16 @@ func parseResponse(httpRes *http.Response, req *cmds.Request) (cmds.Response, er
 				return nil, err
 			}
 			e.Message = string(mes)
-			e.Code = cmds.ErrNormal
+			switch httpRes.StatusCode {
+			case http.StatusNotFound, http.StatusBadRequest:
+				e.Code = cmds.ErrClient
+			case http.StatusTooManyRequests:
+				e.Code = cmds.ErrRateLimited
+			case http.StatusForbidden:
+				e.Code = cmds.ErrForbidden
+			default:
+				e.Code = cmds.ErrNormal
+			}
 		case res.dec == nil:
 			return nil, fmt.Errorf("unknown error content type: %s", contentType)
 		default:


### PR DESCRIPTION
* remove ErrNotFound - it isn't used. If we want to type not-found errors, we should consider adding a new error "subtype" field. All the current errors are effectively transport-level errors.
* remove ErrFatal - it's unclear how this should be handled.
* add ErrRateLimited - requested by @MichaelMure
* add ErrForbidden