### PR TITLE
fallback executor support

### DIFF
--- a/examples/adder/remote/client/main.go
+++ b/examples/adder/remote/client/main.go
@@ -19,16 +19,10 @@ func main() {
 		panic(err)
 	}
 
+	req.Options["encoding"] = cmds.Text
+
 	// create http rpc client
 	client := http.NewClient(":6798")
-
-	// send request to server
-	res, err := client.Send(req)
-	if err != nil {
-		panic(err)
-	}
-
-	req.Options["encoding"] = cmds.Text
 
 	// create an emitter
 	re, err := cli.NewResponseEmitter(os.Stdout, os.Stderr, req)
@@ -36,15 +30,9 @@ func main() {
 		panic(err)
 	}
 
-	// copy received result into cli emitter
-	if pr, ok := req.Command.PostRun[cmds.CLI]; ok {
-		err = pr(res, re)
-	} else {
-		err = cmds.Copy(re, res)
-	}
+	// send request to server
+	err = client.Execute(req, re, nil)
 	if err != nil {
-		re.CloseWithError(err)
+		panic(err)
 	}
-
-	os.Exit(re.Status())
 }

--- a/http/client.go
+++ b/http/client.go
@@ -69,6 +69,11 @@ func NewClient(address string, opts ...ClientOpt) Client {
 func (c *client) Execute(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 	cmd := req.Command
 
+	err := cmd.CheckArguments(req)
+	if err != nil {
+		return err
+	}
+
 	if cmd.PreRun != nil {
 		err := cmd.PreRun(req, env)
 		if err != nil {

--- a/http/client.go
+++ b/http/client.go
@@ -22,11 +22,6 @@ var OptionSkipMap = map[string]bool{
 	"api": true,
 }
 
-// Client is the commands HTTP client interface.
-type Client interface {
-	Send(req *cmds.Request) (cmds.Response, error)
-}
-
 type client struct {
 	serverAddress string
 	httpClient    *http.Client
@@ -48,7 +43,7 @@ func ClientWithAPIPrefix(apiPrefix string) ClientOpt {
 	}
 }
 
-func NewClient(address string, opts ...ClientOpt) Client {
+func NewClient(address string, opts ...ClientOpt) cmds.Executor {
 	if !strings.HasPrefix(address, "http://") {
 		address = "http://" + address
 	}
@@ -81,7 +76,7 @@ func (c *client) Execute(req *cmds.Request, re cmds.ResponseEmitter, env cmds.En
 		}
 	}
 
-	res, err := c.Send(req)
+	res, err := c.send(req)
 	if err != nil {
 		if isConnRefused(err) {
 			err = fmt.Errorf("cannot connect to the api. Is the daemon running? To run as a standalone CLI command remove the api file in `$IPFS_PATH/api`")
@@ -151,7 +146,7 @@ func (c *client) toHTTPRequest(req *cmds.Request) (*http.Request, error) {
 	return httpReq, nil
 }
 
-func (c *client) Send(req *cmds.Request) (cmds.Response, error) {
+func (c *client) send(req *cmds.Request) (cmds.Response, error) {
 	if req.Context == nil {
 		log.Warningf("no context set in request")
 		req.Context = context.Background()

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -44,7 +44,7 @@ func TestClientUserAgent(t *testing.T) {
 
 		c := NewClient(tc.host, ClientWithUserAgent(tc.ua)).(*client)
 		c.httpClient = testClient
-		c.Send(r)
+		c.send(r)
 
 		if !called {
 			t.Error("handler has not been called")
@@ -84,7 +84,7 @@ func TestClientAPIPrefix(t *testing.T) {
 
 		c := NewClient(tc.host, ClientWithAPIPrefix(tc.prefix)).(*client)
 		c.httpClient = testClient
-		c.Send(r)
+		c.send(r)
 
 		if !called {
 			t.Error("handler has not been called")

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -99,7 +99,7 @@ func TestHTTP(t *testing.T) {
 				req.Files = tc.file
 			}
 
-			res, err := c.Send(req)
+			res, err := c.(*client).send(req)
 			if tc.sendErr != nil {
 				if err == nil {
 					t.Fatalf("expected error %q but got nil", tc.sendErr)


### PR DESCRIPTION
This adds fallback support to the HTTP executor. That way, we can try to run a command locally if the daemon is offline.

Note: This is an API breaking change which I will bubble up to both go-ipfs and filecoin. Specifically, `http.NewClient` now returns an `Executor`, not an `http.Client`. The correct way to use this client was to cast it to an executor.