### PR TITLE
helptext: display options for parent commands

### DIFF
--- a/cli/helptext.go
+++ b/cli/helptext.go
@@ -99,6 +99,9 @@ const longHelpFormat = `USAGE
 
 {{.Indent}}For more information about each command, use:
 {{.Indent}}'{{.Path}} <subcmd> --help'
+{{end}}{{if .MoreHelp}}
+{{.Indent}}To include information about arguments of parent commands, use:
+{{.Indent}}'{{.Path}} --help-all'
 {{end}}
 `
 const shortHelpFormat = `USAGE
@@ -113,6 +116,8 @@ SUBCOMMANDS
 {{end}}{{if .MoreHelp}}
 {{.Indent}}For more information about each command, use:
 {{.Indent}}'{{.Path}} <subcmd> --help'
+{{.Indent}}To include information about arguments of parent commands, use:
+{{.Indent}}'{{.Path}} --help-all'
 {{end}}
 `
 
@@ -177,7 +182,6 @@ func makeLongHelpFields(rootName string, path []string, root *cmds.Command, widt
 		Subcommands: cmd.Helptext.Subcommands,
 		Description: cmd.Helptext.ShortDescription,
 		Usage:       cmd.Helptext.Usage,
-		MoreHelp:    (cmd != root),
 	}
 
 	if len(cmd.Helptext.LongDescription) > 0 {
@@ -213,6 +217,8 @@ func HelpAll(rootName string, root *cmds.Command, path []string, out io.Writer) 
 	if err != nil {
 		return err
 	}
+
+	fields.MoreHelp = false
 
 	// display options of parent commands
 	parentOptionsList := make([]string, len(path)-1)

--- a/cli/helptext.go
+++ b/cli/helptext.go
@@ -203,6 +203,21 @@ func LongHelp(rootName string, root *cmds.Command, path []string, out io.Writer)
 		fields.Synopsis = generateSynopsis(width, cmd, pathStr)
 	}
 
+	// display options of parent commands
+	parentOptionsList := make([]string, len(path)-1)
+	for i := len(path) - 1; i > 0; i-- {
+		parentPath := path[:i]
+		parentCmd, err := root.Get(parentPath)
+		if err != nil {
+			return err
+		}
+		parentPathString := strings.Join(parentPath, " ")
+		parentOptionsString := strings.Join(optionText(width, parentCmd), "\n")
+		parentOptionsList = append(parentOptionsList, fmt.Sprintf("%s\n%s", parentPathString, parentOptionsString))
+	}
+	parentOptions := strings.Join(parentOptionsList, "\n\n")
+	fields.Options = fmt.Sprintf("%s\n\n%s", fields.Options, parentOptions)
+
 	// trim the extra newlines (see TrimNewlines doc)
 	fields.TrimNewlines()
 

--- a/opts.go
+++ b/opts.go
@@ -12,6 +12,7 @@ const (
 	TimeoutOpt   = "timeout"
 	OptShortHelp = "h"
 	OptLongHelp  = "help"
+	OptHelpAll   = "help-all"
 	DerefLong    = "dereference-args"
 	StdinName    = "stdin-name"
 	Hidden       = "hidden"


### PR DESCRIPTION
This helps to understand which options are available for the given
subcommand without calling help for parent commands by providing more
informative output.

Resolves ipfs/go-ipfs#6640