### PR TITLE
Fix: disallow POST without Origin nor Referer from specific user agents

### DIFF
--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -174,7 +174,7 @@ func TestUnhandledMethod(t *testing.T) {
 func TestDisallowedUserAgents(t *testing.T) {
 	tcs := []httpTestCase{
 		{
-			// Block Firefox
+			// Block Mozilla* browsers that do not provide origins.
 			Method:   "POST",
 			AllowGet: false,
 			Code:     http.StatusForbidden,
@@ -192,10 +192,13 @@ func TestDisallowedUserAgents(t *testing.T) {
 			},
 		},
 		{
-			// Do not block Chrome
-			Method:   "POST",
-			AllowGet: false,
-			Code:     http.StatusOK,
+			// Do not block a Mozilla* browser that provides an
+			// allowed Origin
+			Method:       "POST",
+			AllowGet:     false,
+			AllowOrigins: []string{"*"},
+			Origin:       "null",
+			Code:         http.StatusOK,
 			ReqHeaders: map[string]string{
 				"User-Agent": "Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; Build/KLP) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30",
 			},

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -170,3 +170,39 @@ func TestUnhandledMethod(t *testing.T) {
 	}
 	tc.test(t)
 }
+
+func TestDisallowedUserAgents(t *testing.T) {
+	tcs := []httpTestCase{
+		{
+			// Block Firefox
+			Method:   "POST",
+			AllowGet: false,
+			Code:     http.StatusForbidden,
+			ReqHeaders: map[string]string{
+				"User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+			},
+		},
+		{
+			// Do not block on GETs
+			Method:   "GET",
+			AllowGet: true,
+			Code:     http.StatusOK,
+			ReqHeaders: map[string]string{
+				"User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+			},
+		},
+		{
+			// Do not block Chrome
+			Method:   "POST",
+			AllowGet: false,
+			Code:     http.StatusOK,
+			ReqHeaders: map[string]string{
+				"User-Agent": "Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; Build/KLP) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc.test(t)
+	}
+}

--- a/http/handler.go
+++ b/http/handler.go
@@ -121,7 +121,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !allowOrigin(r, h.cfg) || !allowReferer(r, h.cfg) {
+	if !allowOrigin(r, h.cfg) || !allowReferer(r, h.cfg) || !allowUserAgent(r, h.cfg) {
 		http.Error(w, "403 - Forbidden", http.StatusForbidden)
 		log.Warnf("API blocked request to %s. (possible CSRF)", r.URL)
 		return


### PR DESCRIPTION
Addresses browsers being able to POST without control due to things like
https://bugzilla.mozilla.org/show_bug.cgi?id=429594