### PR TITLE
Fix go-ipfs#7242: Remove "HEAD" from Allow methods

### DIFF
--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -165,7 +165,7 @@ func TestUnhandledMethod(t *testing.T) {
 		AllowGet: false,
 		Code:     http.StatusMethodNotAllowed,
 		ResHeaders: map[string]string{
-			"Allow": "POST, HEAD, OPTIONS",
+			"Allow": "POST, OPTIONS",
 		},
 	}
 	tc.test(t)

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -165,7 +165,7 @@ func TestUnhandledMethod(t *testing.T) {
 		AllowGet: false,
 		Code:     http.StatusMethodNotAllowed,
 		ResHeaders: map[string]string{
-			"Allow": "POST, OPTIONS",
+			"Allow": "OPTIONS, POST",
 		},
 	}
 	tc.test(t)

--- a/http/handler.go
+++ b/http/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -192,10 +193,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func setAllowedHeaders(w http.ResponseWriter, allowGet bool) {
-	w.Header().Add("Allow", http.MethodOptions)
-	w.Header().Add("Allow", http.MethodPost)
+	allowedMethods := []string{http.MethodOptions, http.MethodPost}
 	if allowGet {
-		w.Header().Add("Allow", http.MethodHead)
-		w.Header().Add("Allow", http.MethodGet)
+		allowedMethods = append(allowedMethods, http.MethodHead, http.MethodGet)
 	}
+	w.Header().Set("Allow", strings.Join(allowedMethods, ", "))
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -107,7 +107,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// The CORS library handles all other requests.
 
 		// Tell the user the allowed methods, and return.
-		setAllowedHeaders(w, h.cfg.AllowGet)
+		setAllowHeader(w, h.cfg.AllowGet)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	case http.MethodPost:
@@ -117,7 +117,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		fallthrough
 	default:
-		setAllowedHeaders(w, h.cfg.AllowGet)
+		setAllowHeader(w, h.cfg.AllowGet)
 		http.Error(w, "405 - Method Not Allowed", http.StatusMethodNotAllowed)
 		log.Warnf("The IPFS API does not support %s requests.", r.Method)
 		return
@@ -192,7 +192,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.root.Call(req, re, h.env)
 }
 
-func setAllowedHeaders(w http.ResponseWriter, allowGet bool) {
+func setAllowHeader(w http.ResponseWriter, allowGet bool) {
 	allowedMethods := []string{http.MethodOptions, http.MethodPost}
 	if allowGet {
 		allowedMethods = append(allowedMethods, http.MethodHead, http.MethodGet)

--- a/http/handler.go
+++ b/http/handler.go
@@ -192,10 +192,10 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func setAllowedHeaders(w http.ResponseWriter, allowGet bool) {
-	w.Header().Add("Allow", http.MethodHead)
 	w.Header().Add("Allow", http.MethodOptions)
 	w.Header().Add("Allow", http.MethodPost)
 	if allowGet {
+		w.Header().Add("Allow", http.MethodHead)
 		w.Header().Add("Allow", http.MethodGet)
 	}
 }


### PR DESCRIPTION
(when GET is not allowed).

Fixes ipfs/go-ipfs#7242