### PR TITLE
fix: allow requests from electron renderer

### DIFF
--- a/http/config.go
+++ b/http/config.go
@@ -176,5 +176,12 @@ func allowUserAgent(r *http.Request, cfg *ServerConfig) bool {
 	// This means the request probably came from a browser and thus, it
 	// should have included Origin or referer headers.
 	ua := r.Header.Get("User-agent")
+
+	// The fetch API in the Electron Renderer process sends no referer or
+	// origin but should be allowed
+	if strings.Contains(ua, "Electron") {
+		return true
+	}
+
 	return !strings.HasPrefix(ua, "Mozilla")
 }

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -203,6 +203,15 @@ func TestDisallowedUserAgents(t *testing.T) {
 				"User-Agent": "Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; Build/KLP) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30",
 			},
 		},
+		{
+			// Do not block the Electron Renderer process
+			Method:       "POST",
+			AllowGet:     false,
+			Code:         http.StatusOK,
+			ReqHeaders: map[string]string{
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.104 Electron/9.0.4 Safari/537.36",
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -205,9 +205,9 @@ func TestDisallowedUserAgents(t *testing.T) {
 		},
 		{
 			// Do not block the Electron Renderer process
-			Method:       "POST",
-			AllowGet:     false,
-			Code:         http.StatusOK,
+			Method:   "POST",
+			AllowGet: false,
+			Code:     http.StatusOK,
 			ReqHeaders: map[string]string{
 				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.104 Electron/9.0.4 Safari/537.36",
 			},


### PR DESCRIPTION
The Electron Renderer process runs in an embedded  browser window so has access to browser-native `fetch`.  If this is used by `ipfs-http-client` to make requests against the HTTP API, the `User-Agent` header is set to a value that looks similar to a browser but no `Origin` or `Referer` headers are sent and they can't be overridden.

The change here is to relax the user agent check to allow through requests from clients with `'Electron'` in their user agents.