### PR TITLE
fix: hide subcommand from short help when no subcommands

### DIFF
--- a/cli/helptext_test.go
+++ b/cli/helptext_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -46,5 +47,52 @@ func TestSynopsisGenerator(t *testing.T) {
 	}
 	if !strings.Contains(syn, "[--]") {
 		t.Fatal("Synopsis should contain options finalizer")
+	}
+	if strings.Contains(syn, "For more information about each command") {
+		t.Fatal("Synopsis should not contain subcommands")
+	}
+}
+
+func TestShortHelp(t *testing.T) {
+	// ShortHelp behaves differently depending on whether the command is the root or not.
+	root := &cmds.Command{
+		Subcommands: map[string]*cmds.Command{
+			"ls": {
+				Helptext: cmds.HelpText{
+					ShortDescription: `
+				Displays the contents of an IPFS or IPNS object(s) at the given path.
+				`},
+			},
+		},
+	}
+	// Ask for the help text for the ls command which has no subcommands
+	path := []string{"ls"}
+	buf := new(bytes.Buffer)
+	ShortHelp("ipfs", root, path, buf)
+	helpText := buf.String()
+	t.Logf("Short help text: %s", helpText)
+	if strings.Contains(helpText, "For more information about each command") {
+		t.Fatal("ShortHelp should not contain subcommand info")
+	}
+}
+
+func TestLongHelp(t *testing.T) {
+	root := &cmds.Command{
+		Subcommands: map[string]*cmds.Command{
+			"ls": {
+				Helptext: cmds.HelpText{
+					ShortDescription: `
+				Displays the contents of an IPFS or IPNS object(s) at the given path.
+				`},
+			},
+		},
+	}
+	path := []string{"ls"}
+	buf := new(bytes.Buffer)
+	LongHelp("ipfs", root, path, buf)
+	helpText := buf.String()
+	t.Logf("Long help text: %s", helpText)
+	if strings.Contains(helpText, "For more information about each command") {
+		t.Fatal("LongHelp should not contain subcommand info")
 	}
 }


### PR DESCRIPTION
ShortHelp always shows the subcommand help prompt even if there are no subcommands. In `ipfs@0.7`

```console
$ ipfs version
ipfs version 0.7.0

$ipfs ls -h
USAGE
  ipfs ls <ipfs-path>... - List directory contents for Unix filesystem objects.

  ipfs ls [--headers | -v] [--resolve-type=false] [--size=false] [--stream | -s] [--] <ipfs-path>...

  Displays the contents of an IPFS or IPNS object(s) at the given path, with
  the following format:
  
    <link base58 hash> <link size in bytes> <link name>
  
  The JSON output contains type information.

  For more information about each command, use:
  'ipfs ls <subcmd> --help'
```

The last 2 lines of the short help are supposed to let the user know that `--help` will get them more help about *this* command. There should be no invitation to check subcommands if there are no subcommands for this command.


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>