### PR TITLE
fix: CLI parsing of files should allow multiple files with the same name

### DIFF
--- a/cli/parse.go
+++ b/cli/parse.go
@@ -332,7 +332,6 @@ func parseArgs(req *cmds.Request, root *cmds.Command, stdin *os.File) error {
 						return err
 					}
 
-					fpath = path.Base(fpath)
 					file = nf
 				}
 


### PR DESCRIPTION
fixes https://github.com/ipfs/go-ipfs/issues/8264