### PR TITLE
Fix my own bug in postrun Execute

### DIFF
--- a/chan.go
+++ b/chan.go
@@ -96,6 +96,10 @@ func (r *chanResponse) Next() (interface{}, error) {
 		ctx = context.Background()
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	select {
 	case v, ok := <-r.ch:
 		if !ok {
@@ -144,6 +148,10 @@ func (re *chanResponseEmitter) Emit(v interface{}) error {
 	}
 
 	ctx := re.req.Context
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	select {
 	case re.ch <- v:

--- a/command_test.go
+++ b/command_test.go
@@ -316,6 +316,7 @@ func TestCancel(t *testing.T) {
 	}
 
 	re, res := NewChanResponsePair(req)
+	cancel()
 
 	go func() {
 		err := re.Emit("abc")
@@ -327,8 +328,6 @@ func TestCancel(t *testing.T) {
 		re.Close()
 		close(wait)
 	}()
-
-	cancel()
 
 	_, err = res.Next()
 	if err != context.Canceled {


### PR DESCRIPTION
I left in a bad condition in https://github.com/ipfs/go-ipfs-cmds/pull/216 which was supposed to be deleted.
This should amend that and adds tests to make sure postruns actually executes if it should.

>What was wrong?

The condition was supposed to be checking `formatters`, but was checking the wrong value.
>Why is this condition removed instead of changed?

We're reading from a map type, even if it's nil we'll just get back the 0 value when indexing it.
In this case that's a nil function pointer, which is checked before being assigned and later used.
`formatters[typer.Type()] != nil`
