### PR TITLE
feat: add command output option

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -28,6 +28,8 @@ func NewExecutor(root *Command) Executor {
 	}
 }
 
+// This is the *CLI* Executor (though is not in that package). The other one is
+// the `client` HTTP Executor (defined in the HTTP package).
 type executor struct {
 	root *Command
 }

--- a/opts.go
+++ b/opts.go
@@ -12,10 +12,13 @@ const (
 	OptLongHelp  = "help"
 	DerefLong    = "dereference-args"
 	StdinName    = "stdin-name"
-	Hidden       = "hidden"
-	HiddenShort  = "H"
-	Ignore       = "ignore"
-	IgnoreRules  = "ignore-rules-path"
+	// FIXME(BLOCKING): Review names. (We may be able to use "output" once
+	//  it's cleaned from subcommands.)
+	OutputFile  = "command-output"
+	Hidden      = "hidden"
+	HiddenShort = "H"
+	Ignore      = "ignore"
+	IgnoreRules = "ignore-rules-path"
 )
 
 // options that are used by this package
@@ -25,6 +28,7 @@ var OptionStreamChannels = BoolOption(ChanOpt, "Stream channel output")
 var OptionTimeout = StringOption(TimeoutOpt, "Set a global timeout on the command")
 var OptionDerefArgs = BoolOption(DerefLong, "Symlinks supplied in arguments are dereferenced")
 var OptionStdinName = StringOption(StdinName, "Assign a name if the file source is stdin.")
+var OptionOutputFile = StringOption(OutputFile, "Filename to save the output in (by default it's redirected to stdout).")
 var OptionHidden = BoolOption(Hidden, HiddenShort, "Include files that are hidden. Only takes effect on recursive add.")
 var OptionIgnore = StringsOption(Ignore, "A rule (.gitignore-stype) defining which file(s) should be ignored (variadic, experimental)")
 var OptionIgnoreRules = StringOption(IgnoreRules, "A path to a file with .gitignore-style ignore rules (experimental)")


### PR DESCRIPTION
Add an option to save command output to a file instead of the `stdout` argument (which is always set to stdout by `go-ipfs` consumer).