### PR TITLE
chore: retract gx tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,6 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )
+
+retract v1.0.22 // old gx tag accidentally pushed as go tag
+retract v2.0.1+incompatible // old gx tag

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,5 @@ require (
 )
 
 retract v1.0.22 // old gx tag accidentally pushed as go tag
+
 retract v2.0.1+incompatible // old gx tag


### PR DESCRIPTION
@Stebalien do you remember the context here, this seems like this should do the job though.

cc @ribasushi

note: Do we need another patch release for this to take effect or is merging into master sufficient?

Pulled versions to retract from https://pkg.go.dev/github.com/ipfs/go-ipfs-cmds?tab=versions. It showed
- v1.0.22 published Aug 22, 2018
- v2.0.1+incompatible Sep 24, 2018