### PR TITLE
fix(http): return error in case of panic

### DIFF
--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -112,6 +112,18 @@ func TestErrors(t *testing.T) {
 			status:  "200 OK",
 			bodyStr: "the reader call returns a reader.",
 		},
+
+		{
+			path:    []string{"panic"},
+			status:  "500 Internal Server Error",
+			bodyStr: `{"Message":"an error occurred","Code":0,"Type":"error"}` + "\n",
+		},
+		{
+			path:       []string{"latepanic"},
+			status:     "200 OK",
+			bodyStr:    `"some value"` + "\n",
+			errTrailer: "an error occurred",
+		},
 	}
 
 	mkTest := func(tc testcase) func(*testing.T) {

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -287,6 +287,19 @@ var (
 					}),
 				},
 			},
+
+			"panic": {
+				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+					panic("Invalid memory address or nil pointer dereference")
+				},
+			},
+			"latepanic": {
+				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+					re.Emit("some value")
+					panic("Invalid memory address or nil pointer dereference")
+				},
+				Type: "",
+			},
 		},
 	}
 )


### PR DESCRIPTION
Address issue: https://github.com/ipfs/go-ipfs-cmds/issues/249

The new tests cover a case of sync http commands (e.g. `/cat`) and 'progress' commands (e.g. `/add`) panicking.