### PR TITLE
Preparing a `v2.0.2+incompatible` pre-release to properly retract `v2.0.1+incompatible`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,4 @@ retract v1.0.22 // old gx tag accidentally pushed as go tag
 
 retract v2.0.1+incompatible // old gx tag
 
-retract v2.0.2-retract // we need to use a newer version than v2.0.1 to retract v2.0.1+incompatible, but we can retract ourself directly once done
+retract v2.0.2+incompatible // we need to use a newer version than v2.0.1 to retract v2.0.1+incompatible, but we can retract ourself directly once done

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ require (
 retract v1.0.22 // old gx tag accidentally pushed as go tag
 
 retract v2.0.1+incompatible // old gx tag
+
+retract v2.0.2-retract // we need to use a newer version than v2.0.1 to retract v2.0.1+incompatible, but we can retract ourself directly once done


### PR DESCRIPTION
We need to issue a higher version tag which self-retract itself in order to retract `v2.0.1+incompatible`
I have chosen a pre-release `v2.0.2+incompatible` value so that it will still be possible to create v2.0.x versions in the future without conflicting with it.

After merging this, please tag the latest master with tag `v2.0.2+incompatible` and push the tag to github 🙏🏻 

As per the Go spec:
> To retract a version, a module author should add a retract directive to go.mod, then publish a new version containing that directive. The new version must be higher than other release or pre-release versions; that is, the `@latest` [version query](https://go.dev/ref/mod#version-queries) should resolve to the new version before retractions are considered
> A version containing retractions may retract itself. If the highest release or pre-release version of a module retracts itself, the `@latest` query resolves to a lower version after retracted versions are excluded.