### PR TITLE
Support HTTPS when using a specific API instance

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -85,7 +85,9 @@ func ClientWithRawAbsPath(rawAbsPath bool) ClientOpt {
 
 // NewClient constructs a new HTTP-backed command executor.
 func NewClient(address string, opts ...ClientOpt) cmds.Executor {
-	if !strings.HasPrefix(address, "http://") {
+	if strings.Contains(address, "443") {
+		address = "https://" + address
+	} else if !strings.HasPrefix(address, "http://") {
 		address = "http://" + address
 	}
 


### PR DESCRIPTION
The `--api` flag in Kubo is not currently usable with an API instance behind TLS. This change allows HTTPS to be used.