### PR TITLE
feat(errors): add dedicated error type for blocked content

### DIFF
--- a/error.go
+++ b/error.go
@@ -22,6 +22,7 @@ const (
 	// ErrForbidden is returned when the client doesn't have permission to
 	// perform the requested operation.
 	ErrForbidden
+	ErrBlocked
 )
 
 func (e ErrorType) Error() string {
@@ -40,6 +41,8 @@ func (e ErrorType) String() string {
 		return "rate limited"
 	case ErrForbidden:
 		return "request forbidden"
+	case ErrBlocked:
+		return "content blocked"
 	default:
 		return "unknown error code"
 	}

--- a/http/parse.go
+++ b/http/parse.go
@@ -235,6 +235,8 @@ func parseResponse(httpRes *http.Response, req *cmds.Request) (cmds.Response, er
 				e.Code = cmds.ErrRateLimited
 			case http.StatusForbidden:
 				e.Code = cmds.ErrForbidden
+			case http.StatusGone, http.StatusUnavailableForLegalReasons:
+				e.Code = cmds.ErrBlocked
 			default:
 				e.Code = cmds.ErrNormal
 			}

--- a/http/responseemitter.go
+++ b/http/responseemitter.go
@@ -238,8 +238,11 @@ func (re *responseEmitter) sendErr(err *cmds.Error) {
 
 	// Set the status from the error code.
 	status := http.StatusInternalServerError
-	if err.Code == cmds.ErrClient {
+	switch err.Code {
+	case cmds.ErrClient:
 		status = http.StatusBadRequest
+	case cmds.ErrBlocked:
+		status = http.StatusUnavailableForLegalReasons
 	}
 	re.w.WriteHeader(status)
 


### PR DESCRIPTION
Changes:
- Add new `ErrBlocked` error type in `errors.go` 
- Handle HTTP 410 (Gone) and 451 (Unavailable For Legal Reasons) status codes in response parsing
- Map blocked content errors to appropriate status codes in response emitter

This provides proper error types for content blocking rather than relying on string matching. Works in conjunction with error type improvements in boxo.

Inspired by:  ipfs/boxo#591
Related to: ipfs/boxo#855

