### PR TITLE
feat: expose HTTP headers on cmds.Request

### DIFF
--- a/http/headers_test.go
+++ b/http/headers_test.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	cmds "github.com/ipfs/go-ipfs-cmds"
+)
+
+// TestRequestHeadersForwarded confirms that HTTP headers on the inbound
+// request are made available to command handlers via [cmds.Request.Headers].
+// This lets handlers read request-scoped metadata (e.g. correlation ids)
+// without needing custom middleware to lift them into the context.
+func TestRequestHeadersForwarded(t *testing.T) {
+	const (
+		marker      = "X-Test-Marker"
+		markerValue = "marker-42"
+	)
+
+	type captured struct {
+		headers map[string][]string
+	}
+	captureCh := make(chan captured, 1)
+
+	root := &cmds.Command{
+		Subcommands: map[string]*cmds.Command{
+			"echo-headers": {
+				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+					var c captured
+					if req.Headers != nil {
+						c.headers = map[string][]string(req.Headers.Clone())
+					}
+					captureCh <- c
+					return re.Emit("ok")
+				},
+			},
+		},
+	}
+
+	cfg := NewServerConfig()
+	cfg.SetAllowedOrigins("*")
+	cfg.SetAllowedMethods("POST")
+	srv := httptest.NewServer(NewHandler(nil, root, cfg))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, ClientWithHeader(marker, markerValue))
+
+	req, err := cmds.NewRequest(context.Background(), []string{"echo-headers"}, nil, nil, nil, root)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	emitter, response := cmds.NewChanResponsePair(req)
+	go func() {
+		_ = c.Execute(req, emitter, nil)
+	}()
+
+	// Drain the response so the server-side handler runs to completion.
+	// Errors here are not load-bearing for this test; we want the side
+	// effect on the captureCh.
+	_, _ = response.Next()
+
+	got, ok := <-captureCh
+	if !ok {
+		t.Fatal("handler did not run")
+	}
+	if got.headers == nil {
+		t.Fatal("Request.Headers was nil; expected populated for HTTP-dispatched requests")
+	}
+	want := []string{markerValue}
+	if !reflect.DeepEqual(got.headers[marker], want) {
+		t.Fatalf("Request.Headers[%q] = %v, want %v", marker, got.headers[marker], want)
+	}
+}
+
+// TestLocalRequestHeadersNil confirms that the local in-process executor
+// path does not fabricate a Headers map. A nil http.Header is the
+// documented sentinel for "no HTTP transport"; handlers can call .Get on
+// it without panicking.
+func TestLocalRequestHeadersNil(t *testing.T) {
+	root := &cmds.Command{
+		Subcommands: map[string]*cmds.Command{
+			"check": {
+				Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
+					if req.Headers != nil {
+						t.Errorf("Request.Headers should be nil for local dispatch; got %v", req.Headers)
+					}
+					if got := req.Headers.Get("X-Anything"); got != "" {
+						t.Errorf("http.Header.Get on nil should return empty; got %q", got)
+					}
+					return re.Emit("ok")
+				},
+			},
+		},
+	}
+
+	req, err := cmds.NewRequest(context.Background(), []string{"check"}, nil, nil, nil, root)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if req.Headers != nil {
+		t.Fatalf("fresh local Request should have nil Headers; got %v", req.Headers)
+	}
+
+	exec := cmds.NewExecutor(root)
+	emitter, response := cmds.NewChanResponsePair(req)
+	go func() {
+		_ = exec.Execute(req, emitter, nil)
+	}()
+	if _, err := response.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+}

--- a/http/headers_test.go
+++ b/http/headers_test.go
@@ -9,10 +9,10 @@ import (
 	cmds "github.com/ipfs/go-ipfs-cmds"
 )
 
-// TestRequestHeadersForwarded confirms that HTTP headers on the inbound
-// request are made available to command handlers via [cmds.Request.Headers].
-// This lets handlers read request-scoped metadata (e.g. correlation ids)
-// without needing custom middleware to lift them into the context.
+// TestRequestHeadersForwarded checks that the HTTP transport forwards
+// inbound request headers to command handlers via [cmds.Request.Headers].
+// Guards the contract that handlers can read request-scoped metadata
+// (e.g. correlation ids) without needing custom middleware.
 func TestRequestHeadersForwarded(t *testing.T) {
 	const (
 		marker      = "X-Test-Marker"
@@ -58,8 +58,7 @@ func TestRequestHeadersForwarded(t *testing.T) {
 	}()
 
 	// Drain the response so the server-side handler runs to completion.
-	// Errors here are not load-bearing for this test; we want the side
-	// effect on the captureCh.
+	// This test asserts on captureCh, not on response errors.
 	_, _ = response.Next()
 
 	got, ok := <-captureCh
@@ -75,10 +74,9 @@ func TestRequestHeadersForwarded(t *testing.T) {
 	}
 }
 
-// TestLocalRequestHeadersNil confirms that the local in-process executor
-// path does not fabricate a Headers map. A nil http.Header is the
-// documented sentinel for "no HTTP transport"; handlers can call .Get on
-// it without panicking.
+// TestLocalRequestHeadersNil checks that the local in-process executor
+// leaves Request.Headers nil. A nil http.Header is the "no HTTP transport"
+// sentinel; handlers can call .Get on it without panicking.
 func TestLocalRequestHeadersNil(t *testing.T) {
 	root := &cmds.Command{
 		Subcommands: map[string]*cmds.Command{

--- a/http/parse.go
+++ b/http/parse.go
@@ -167,6 +167,12 @@ func parseRequest(r *http.Request, root *cmds.Command) (*cmds.Request, error) {
 		return nil, err
 	}
 
+	// Forward HTTP headers so command handlers can read request-scoped
+	// metadata (e.g. correlation ids) without needing custom middleware.
+	// We clone to insulate handlers from later mutations of r.Header by
+	// the http stack.
+	req.Headers = r.Header.Clone()
+
 	err = cmd.CheckArguments(req)
 	if err != nil {
 		return nil, err

--- a/http/parse.go
+++ b/http/parse.go
@@ -167,10 +167,10 @@ func parseRequest(r *http.Request, root *cmds.Command) (*cmds.Request, error) {
 		return nil, err
 	}
 
-	// Forward HTTP headers so command handlers can read request-scoped
-	// metadata (e.g. correlation ids) without needing custom middleware.
-	// We clone to insulate handlers from later mutations of r.Header by
-	// the http stack.
+	// Forward request headers so handlers can read request-scoped
+	// metadata (correlation ids, trace context, feature flags) without
+	// custom middleware. Clone so handler writes to req.Headers do not
+	// leak back into r.Header.
 	req.Headers = r.Header.Clone()
 
 	err = cmd.CheckArguments(req)

--- a/request.go
+++ b/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"net/http"
 	"reflect"
 
 	"github.com/ipfs/boxo/files"
@@ -19,6 +20,19 @@ type Request struct {
 	Options   OptMap
 
 	Files files.Directory
+
+	// Headers carries the HTTP headers of the originating request when
+	// the command was dispatched over the HTTP transport. It is nil for
+	// commands invoked through the local executor (e.g. CLI commands
+	// running offline). Handlers that read it should treat nil and an
+	// empty Header as equivalent (http.Header.Get is safe on a nil
+	// receiver).
+	//
+	// This is the recommended way for handlers to read request-scoped
+	// metadata supplied by callers, e.g. correlation ids, trace context,
+	// or feature flags. The HTTP transport populates it from
+	// http.Request.Header; the local executor leaves it nil.
+	Headers http.Header
 
 	bodyArgs *arguments
 }

--- a/request.go
+++ b/request.go
@@ -21,17 +21,16 @@ type Request struct {
 
 	Files files.Directory
 
-	// Headers carries the HTTP headers of the originating request when
-	// the command was dispatched over the HTTP transport. It is nil for
-	// commands invoked through the local executor (e.g. CLI commands
-	// running offline). Handlers that read it should treat nil and an
-	// empty Header as equivalent (http.Header.Get is safe on a nil
-	// receiver).
+	// Headers carries a clone of the inbound HTTP request's header
+	// map, so handlers can read or modify it without affecting the
+	// live *http.Request. The HTTP transport populates it from
+	// http.Request.Header; the local executor (CLI commands running
+	// offline) leaves it nil. Handlers can treat nil and an empty
+	// Header as equivalent: http.Header.Get is safe on a nil
+	// receiver, and ranging over a nil map yields zero entries.
 	//
-	// This is the recommended way for handlers to read request-scoped
-	// metadata supplied by callers, e.g. correlation ids, trace context,
-	// or feature flags. The HTTP transport populates it from
-	// http.Request.Header; the local executor leaves it nil.
+	// Use Headers for request-scoped metadata supplied by callers:
+	// correlation ids, trace context, feature flags.
 	Headers http.Header
 
 	bodyArgs *arguments


### PR DESCRIPTION
Adds a `Headers` field on `cmds.Request` so handlers can read request-scoped HTTP headers (correlation ids, trace context, feature flags) directly, without custom middleware to lift them into `context.Context`.

The HTTP transport clones `r.Header` into the field so handlers can read or modify it without affecting the live `*http.Request`. The local executor leaves it nil; `http.Header.Get` is safe on a nil receiver, so handlers need no nil check.