### PR TITLE
fix typo: occured -> occurred

### DIFF
--- a/chan_test.go
+++ b/chan_test.go
@@ -68,7 +68,7 @@ func TestChanResponsePair(t *testing.T) {
 	tcs := []testcase{
 		{values: []any{1, 2, 3}},
 		{values: []any{1, 2, 3}, closeErr: io.EOF},
-		{values: []any{1, 2, 3}, closeErr: errors.New("an error occured")},
+		{values: []any{1, 2, 3}, closeErr: errors.New("an error occurred")},
 	}
 
 	for i, tc := range tcs {

--- a/command.go
+++ b/command.go
@@ -158,7 +158,7 @@ func (c *Command) Call(req *Request, re ResponseEmitter, env Environment) {
 
 	err := c.call(req, re, env)
 	if err != nil {
-		log.Debugf("error occured in call, closing with error: %s", err)
+		log.Debugf("error occurred in call, closing with error: %s", err)
 	}
 
 	closeErr = re.CloseWithError(err)


### PR DESCRIPTION
Fix two occurrences of 'occured' (typo) in a log message and test string.